### PR TITLE
adding and testing the low res catalog

### DIFF
--- a/catalogs/test-lumi/catalog.yaml
+++ b/catalogs/test-lumi/catalog.yaml
@@ -1,0 +1,6 @@
+sources:
+  IFS-NEMO:
+    description: IFS-NEMO coupled model
+    driver: yaml_file_cat
+    args:
+        path: "{{CATALOG_DIR}}/catalog/IFS-NEMO/main.yaml"

--- a/catalogs/test-lumi/catalog/IFS-NEMO/main.yaml
+++ b/catalogs/test-lumi/catalog/IFS-NEMO/main.yaml
@@ -1,0 +1,6 @@
+sources:
+  test:
+    description: FDB IFS/NEMO control run (ensemble) with double precision
+    driver: yaml_file_cat
+    args:
+      path: '{{CATALOG_DIR}}/test.yaml'

--- a/catalogs/test-lumi/catalog/IFS-NEMO/test.yaml
+++ b/catalogs/test-lumi/catalog/IFS-NEMO/test.yaml
@@ -1,0 +1,103 @@
+sources:
+  monthly-r025-atm2d: &base-default
+    args: &args-default
+      request: &request-default
+        class: d1
+        dataset: climate-dt
+        activity: HighResMIP 
+        experiment: cont
+        generation: 1
+        model: IFS-NEMO
+        resolution: standard
+        realization: 1
+        expver: 'a1d7'
+        type: fc
+        stream: clmn
+        year: 2020
+        month: 1
+        param: 228
+        levtype: sfc
+      data_start_date: 20200101T0000
+      data_end_date: 20200331T0000
+      chunks: MS  # Default time chunk size
+      savefreq: MS  # at what frequency are data saved
+      timestep: h  # base timestep for step timestyle
+      timestyle: yearmonth  # variable date or variable step
+    description: monthly 2d atmospheric data on regular r025 grid.
+    driver: gsv
+    metadata: &metadata-default
+      fdb_home: /scratch/project_465000454/maxness/MN5_Intermediate_Simulation_3_Months_Reduced_Output/fdb/REGULARLL_grids/etc
+      fdb_path: /scratch/project_465000454/maxness/MN5_Intermediate_Simulation_3_Months_Reduced_Output/fdb/REGULARLL_grids/etc/fdb/config.yaml
+      eccodes_path: /projappl/project_465000454/jvonhar/aqua/eccodes/eccodes-2.32.5/definitions
+      variables: [144, 146, 147, 151, 164, 165, 166, 169, 175, 176, 177, 178, 179, 180, 181, 182, 212, 228, 228004]
+      source_grid_name: lon-lat
+      fixer_name: ifs-nemo-destine-v1-monthly
+
+  monthly-r025-atm3d:
+    <<: *base-default
+    description: monhly 3D atmospheric atmospheric data on regular r025 grid.
+    args:
+      <<: *args-default
+      request:
+        <<: *request-default
+        param: 131
+        levtype: pl
+        levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600,
+          700, 850, 925, 1000]
+    metadata:
+      <<: *metadata-default
+      levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 700,
+        850, 925, 1000]
+      variables: [130, 131, 132, 133]
+
+  monthly-r025-oce2d:
+    <<: *base-default
+    description: monthly 2D oceanic data on native grid eORCA25.
+    args:
+      <<: *args-default
+      request:
+        <<: *request-default
+        param: 263000
+        levtype: o2d
+    metadata:
+      <<: *metadata-default
+      variables: [263000, 263001, 263008,
+        263100, 263101, 263121, 263122]
+      source_grid_name: eORCA025-2d
+
+  monthly-r025-oce3d:
+    <<: *base-default
+    description: monthly 3D oceanic data on native grid eORCA25.
+    args:
+      <<: *args-default
+      request:
+        <<: *request-default
+        param: 263500
+        levtype: o3d
+        levelist: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+          19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
+          37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
+          55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72,
+          73, 74, 75]
+    metadata:
+      <<: *metadata-default
+      levels: [0.5057600140571594, 1.5558552742004395, 2.6676816940307617, 3.8562798500061035,
+        5.140361309051514, 6.543033599853516, 8.09251880645752, 9.822750091552734,
+        11.773679733276367, 13.99103832244873, 16.52532196044922, 19.42980194091797,
+        22.75761604309082, 26.558300018310547, 30.874561309814453, 35.740203857421875,
+        41.180023193359375, 47.21189498901367, 53.85063552856445, 61.11283874511719,
+        69.02168273925781, 77.61116027832031, 86.92942810058594, 97.04131317138672,
+        108.03028106689453, 120.0, 133.07582092285156, 147.40625, 163.16445922851562,
+        180.5499267578125, 199.7899627685547, 221.14117431640625, 244.890625, 271.35638427734375,
+        300.88751220703125, 333.8628234863281, 370.6884765625, 411.7938537597656,
+        457.6256103515625, 508.639892578125, 565.2922973632812, 628.0260009765625,
+        697.2586669921875, 773.3682861328125, 856.678955078125, 947.4478759765625,
+        1045.854248046875, 1151.9912109375, 1265.8614501953125, 1387.376953125, 1516.3636474609375,
+        1652.5684814453125, 1795.6707763671875, 1945.2955322265625, 2101.026611328125,
+        2262.421630859375, 2429.025146484375, 2600.38037109375, 2776.039306640625,
+        2955.5703125, 3138.56494140625, 3324.640869140625, 3513.445556640625, 3704.65673828125,
+        3897.98193359375, 4093.15869140625, 4289.95263671875, 4488.15478515625, 4687.5810546875,
+        4888.06982421875, 5089.478515625, 5291.68310546875, 5494.5751953125, 5698.060546875,
+        5902.0576171875]
+      variables: [263500, 263501]
+      source_grid_name: eORCA025-3d-level

--- a/catalogs/test-lumi/machine.yaml
+++ b/catalogs/test-lumi/machine.yaml
@@ -1,0 +1,5 @@
+lumi:
+  paths:
+    grids: /pfs/lustrep3/projappl/project_465000454/data/AQUA/grids
+    weights: /pfs/lustrep3/projappl/project_465000454/data/AQUA/weights
+    areas: /pfs/lustrep3/projappl/project_465000454/data/AQUA/areas


### PR DESCRIPTION
This is the first PR with a new `test-lumi` catalog that allows for loading the low resolution test by @maxnessbsc and should address the #3. I am currently able to open all the sources from the technical point of view but I did not have time to verify their consistency from the physical point of view yet. 

cc: @kellekai 

Please notice that to access this data you should
- checkout the most recent AQUA main version on LUMI
- create the proper conda environment
- checkout the current repo and switch to this branch: `git checkout git@github.com:DestinE-Climate-DT/Climate-DT-catalog.git; git checkout test-lowres`
- install AQUA: `aqua install lumi -e $HOME/AQUA/config`
- install the DestinE test catalog: `aqua add test-lumi -e $HOME/Climate-DT-catalog/catalogs/test-lumi`