### PR TITLE
Fix new position of fdb on lumi

### DIFF
--- a/catalogs/lumi/catalog/ICON/historical-1990.yaml
+++ b/catalogs/lumi/catalog/ICON/historical-1990.yaml
@@ -27,8 +27,8 @@ sources:
     #description: hourly data on native grid Tco2559 (about 5km).
     driver: gsv
     metadata: &metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       eccodes_path: /projappl/project_465000454/jvonhar/aqua/eccodes/eccodes-2.32.5/definitions
       variables: [78, 79, 134, 137, 228164, 235, 260048, 146, 147, 169, 175, 176,
         177, 178, 179, 140101, 140102, 130, 151, 165, 166, 167, 168]

--- a/catalogs/lumi/catalog/ICON/ssp370.yaml
+++ b/catalogs/lumi/catalog/ICON/ssp370.yaml
@@ -27,8 +27,8 @@ sources:
     #description: hourly data on native grid Tco2559 (about 5km).
     driver: gsv
     metadata: &metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       eccodes_path: /projappl/project_465000454/jvonhar/aqua/eccodes/eccodes-2.32.5/definitions
       variables: [78, 79, 134, 137, 228164, 235, 260048, 146, 147, 169, 175, 176,
         177, 178, 179, 140101, 140102, 130, 151, 165, 166, 167, 168]

--- a/catalogs/lumi/catalog/IFS-FESOM/story-2017-T2K.yaml
+++ b/catalogs/lumi/catalog/IFS-FESOM/story-2017-T2K.yaml
@@ -29,8 +29,8 @@ sources:
     #description: hourly data on native grid Tco2559 (about 5km).
     driver: gsv
     metadata: &metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       eccodes_path: /projappl/project_465000454/jvonhar/aqua/eccodes/eccodes-2.32.5/definitions
       variables: [78, 79, 134, 137, 141, 148, 151, 159, 164, 165, 166, 167, 168, 186,
         187, 188, 235, 260048, 8, 9, 144, 146, 147, 169, 175, 176, 177, 178, 179,
@@ -106,8 +106,8 @@ sources:
         resolution: standard
         levtype: o2d
     metadata:
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       variables: [263000, 263001, 263002, 263003, 263004, 263100, 263101, 263124]
       source_grid_name: fesom-hpz7-nested
 
@@ -129,7 +129,7 @@ sources:
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69]
     metadata:
       <<: *metadata-default
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       levels: [2.5, 7.5, 12.5, 17.5, 22.5, 27.5, 32.5, 37.5, 42.5, 47.5, 52.5, 57.5,
         62.5, 67.5, 72.5, 77.5, 82.5, 87.5, 92.5, 97.5, 105, 115, 125, 135, 145, 155,
         165, 175, 185, 195, 210, 230, 250, 270, 290, 320, 360, 400, 440, 480, 520,
@@ -151,8 +151,8 @@ sources:
         resolution: standard
         levtype: o2d
     metadata:
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       variables: [263000, 263001, 263002, 263003, 263004, 263100, 263101, 263124]
       source_grid_name: fesom-hpz9-nested
 
@@ -174,7 +174,7 @@ sources:
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69]
     metadata:
       <<: *metadata-default
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       levels: [2.5, 7.5, 12.5, 17.5, 22.5, 27.5, 32.5, 37.5, 42.5, 47.5, 52.5, 57.5,
         62.5, 67.5, 72.5, 77.5, 82.5, 87.5, 92.5, 97.5, 105, 115, 125, 135, 145, 155,
         165, 175, 185, 195, 210, 230, 250, 270, 290, 320, 360, 400, 440, 480, 520,
@@ -195,7 +195,7 @@ sources:
         resolution: high
     metadata:
       <<: *metadata-default
-      fdb_path: /users/lrb_465000454_fdb/native/etc/fdb/config.yaml
+      fdb_path: /appl/local/climatedt/native/etc/fdb/config.yaml
       source_grid_name: tco1279
 
   hourly-native-atm3d:
@@ -230,7 +230,7 @@ sources:
 #         resolution: high
 #     metadata:
 #       <<: *metadata-default
-#       fdb_path: /users/lrb_465000454_fdb/native/etc/fdb/config.yaml
+#       fdb_path: /appl/local/climatedt/native/etc/fdb/config.yaml
 #       variables: [263000, 263001, 263002, 263003, 263004,
 #         263100, 263101, 263124]
 #       source_grid_name: ng5-nodes-2d

--- a/catalogs/lumi/catalog/IFS-FESOM/story-2017-control.yaml
+++ b/catalogs/lumi/catalog/IFS-FESOM/story-2017-control.yaml
@@ -28,8 +28,8 @@ sources:
     #description: hourly data on native grid Tco2559 (about 5km).
     driver: gsv
     metadata: &metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       eccodes_path: /projappl/project_465000454/jvonhar/aqua/eccodes/eccodes-2.32.5/definitions
       variables: [78, 79, 134, 137, 141, 148, 151, 159, 164, 165, 166, 167, 168, 186,
         187, 188, 235, 260048, 8, 9, 144, 146, 147, 169, 175, 176, 177, 178, 179,
@@ -190,8 +190,8 @@ sources:
         resolution: high
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb/native
-      fdb_path: /users/lrb_465000454_fdb/native/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt/native
+      fdb_path: /appl/local/climatedt/native/etc/fdb/config.yaml
       source_grid_name: tco1279
 
   hourly-native-atm3d:
@@ -210,8 +210,8 @@ sources:
       levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 700,
         850, 925, 1000]
       variables: [129, 130, 131, 132, 133, 135, 157, 246]
-      fdb_home: /users/lrb_465000454_fdb/native
-      fdb_path: /users/lrb_465000454_fdb/native/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt/native
+      fdb_path: /appl/local/climatedt/native/etc/fdb/config.yaml
       source_grid_name: tco1279
 
   # OCEANIC NATIVE IS NOT READ BY THE GSV RETRIEVER
@@ -227,7 +227,7 @@ sources:
   #       resolution: high
   #   metadata:
   #     <<: *metadata-default
-  #     fdb_path: /users/lrb_465000454_fdb/native/etc/fdb/config.yaml
+  #     fdb_path: /appl/local/climatedt/native/etc/fdb/config.yaml
   #     variables: [263000, 263001, 263002, 263003, 263004,
   #        263100, 263101, 263124]
   #     #variables: [263124]

--- a/catalogs/lumi/catalog/IFS-FESOM/story-2017-historical.yaml
+++ b/catalogs/lumi/catalog/IFS-FESOM/story-2017-historical.yaml
@@ -29,8 +29,8 @@ sources:
     #description: hourly data on native grid Tco2559 (about 5km).
     driver: gsv
     metadata: &metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       eccodes_path: /projappl/project_465000454/jvonhar/aqua/eccodes/eccodes-2.32.5/definitions
       variables: [78, 79, 134, 137, 141, 148, 151, 159, 164, 165, 166, 167, 168, 186,
         187, 188, 235, 260048, 8, 9, 144, 146, 147, 169, 175, 176, 177, 178, 179,
@@ -190,8 +190,8 @@ sources:
         resolution: high
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb/native
-      fdb_path: /users/lrb_465000454_fdb/native/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt/native
+      fdb_path: /appl/local/climatedt/native/etc/fdb/config.yaml
       source_grid_name: tco1279
 
   hourly-native-atm3d:
@@ -211,8 +211,8 @@ sources:
         850, 925, 1000]
       variables: [129, 130, 131, 132, 133, 135, 157, 246]
       source_grid_name: tco1279
-      fdb_home: /users/lrb_465000454_fdb/native
-      fdb_path: /users/lrb_465000454_fdb/native/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt/native
+      fdb_path: /appl/local/climatedt/native/etc/fdb/config.yaml
 
 # OCEANIC NATIVE IS NOT READ BY THE GSV RETRIEVER
 #   hourly-native-oce2d:
@@ -228,7 +228,7 @@ sources:
 #         resolution: high
 #     metadata:
 #       <<: *metadata-default
-#       fdb_path: /users/lrb_465000454_fdb/native/etc/fdb/config.yaml
+#       fdb_path: /appl/local/climatedt/native/etc/fdb/config.yaml
 #       variables: [263000, 263001, 263002, 263003, 263004,
 #         263100, 263101, 263124]
 #       source_grid_name: ng5-nodes-2d

--- a/catalogs/lumi/catalog/IFS-NEMO/a16z.yaml
+++ b/catalogs/lumi/catalog/IFS-NEMO/a16z.yaml
@@ -27,8 +27,8 @@ sources:
     description: hourly data on native grid .
     driver: gsv
     metadata: &metadata-default
-      fdb_home: /users/lrb_465000454_fdb/native
-      fdb_path: /users/lrb_465000454_fdb/native/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt/native
+      fdb_path: /appl/local/climatedt/native/etc/fdb/config.yaml
       eccodes_path: /projappl/project_465000454/jvonhar/aqua/eccodes/eccodes-2.32.5/definitions
       variables: [78, 79, 134, 137, 141, 148, 151, 159, 164, 165, 166, 167, 168, 186,
         187, 188, 235, 260048, 8, 9, 144, 146, 147, 169, 175, 176, 177, 178, 179,
@@ -122,8 +122,8 @@ sources:
         resolution: standard
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       source_grid_name: hpz7-nested
 
   hourly-hpz7-atm3d:
@@ -141,8 +141,8 @@ sources:
           700, 850, 925, 1000]
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 700,
         850, 925, 1000]
       variables: [60, 129, 130, 131, 132, 133, 135, 157, 246]
@@ -162,8 +162,8 @@ sources:
         levtype: o2d
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       variables: [263000, 263001, 263003, 263004, 263008, 263009, 263021, 263022,
         263100, 263101, 263121, 263122, 263124]
       source_grid_name: nemo-eORCA025-hpz7-nested
@@ -187,8 +187,8 @@ sources:
           73, 74, 75]
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       levels: [0.5057600140571594, 1.5558552742004395, 2.6676816940307617, 3.8562798500061035,
         5.140361309051514, 6.543033599853516, 8.09251880645752, 9.822750091552734,
         11.773679733276367, 13.99103832244873, 16.52532196044922, 19.42980194091797,

--- a/catalogs/lumi/catalog/IFS-NEMO/a17r.yaml
+++ b/catalogs/lumi/catalog/IFS-NEMO/a17r.yaml
@@ -27,8 +27,8 @@ sources:
     description: hourly data on native grid .
     driver: gsv
     metadata: &metadata-default
-      fdb_home: /users/lrb_465000454_fdb/native
-      fdb_path: /users/lrb_465000454_fdb/native/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt/native
+      fdb_path: /appl/local/climatedt/native/etc/fdb/config.yaml
       eccodes_path: /projappl/project_465000454/jvonhar/aqua/eccodes/eccodes-2.32.5/definitions
       variables: [78, 79, 134, 137, 141, 148, 151, 159, 164, 165, 166, 167, 168, 186,
         187, 188, 235, 260048, 8, 9, 144, 146, 147, 169, 175, 176, 177, 178, 179,
@@ -122,8 +122,8 @@ sources:
         resolution: standard
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       source_grid_name: hpz7-nested
 
   hourly-hpz7-atm3d:
@@ -141,8 +141,8 @@ sources:
           700, 850, 925, 1000]
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 700,
         850, 925, 1000]
       variables: [60, 129, 130, 131, 132, 133, 135, 157, 246]
@@ -162,8 +162,8 @@ sources:
         levtype: o2d
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       variables: [263000, 263001, 263003, 263004, 263008, 263009, 263021, 263022,
         263100, 263101, 263121, 263122, 263124]
       source_grid_name: nemo-eORCA025-hpz7-nested
@@ -187,8 +187,8 @@ sources:
           73, 74, 75]
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       levels: [0.5057600140571594, 1.5558552742004395, 2.6676816940307617, 3.8562798500061035,
         5.140361309051514, 6.543033599853516, 8.09251880645752, 9.822750091552734,
         11.773679733276367, 13.99103832244873, 16.52532196044922, 19.42980194091797,

--- a/catalogs/lumi/catalog/IFS-NEMO/a18j.yaml
+++ b/catalogs/lumi/catalog/IFS-NEMO/a18j.yaml
@@ -27,8 +27,8 @@ sources:
     description: hourly data on native grid .
     driver: gsv
     metadata: &metadata-default
-      fdb_home: /users/lrb_465000454_fdb/native
-      fdb_path: /users/lrb_465000454_fdb/native/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt/native
+      fdb_path: /appl/local/climatedt/native/etc/fdb/config.yaml
       eccodes_path: /projappl/project_465000454/jvonhar/aqua/eccodes/eccodes-2.32.5/definitions
       variables: [78, 79, 134, 137, 141, 148, 151, 159, 164, 165, 166, 167, 168, 186,
         187, 188, 235, 260048, 8, 9, 144, 146, 147, 169, 175, 176, 177, 178, 179,
@@ -122,8 +122,8 @@ sources:
         resolution: standard
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       source_grid_name: hpz7-nested
 
   hourly-hpz7-atm3d:
@@ -141,8 +141,8 @@ sources:
           700, 850, 925, 1000]
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 700,
         850, 925, 1000]
       variables: [60, 129, 130, 131, 132, 133, 135, 157, 246]
@@ -162,8 +162,8 @@ sources:
         levtype: o2d
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       variables: [263000, 263001, 263003, 263004, 263008, 263009, 263021, 263022,
         263100, 263101, 263121, 263122, 263124]
       source_grid_name: nemo-eORCA025-hpz7-nested
@@ -187,8 +187,8 @@ sources:
           73, 74, 75]
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       levels: [0.5057600140571594, 1.5558552742004395, 2.6676816940307617, 3.8562798500061035,
         5.140361309051514, 6.543033599853516, 8.09251880645752, 9.822750091552734,
         11.773679733276367, 13.99103832244873, 16.52532196044922, 19.42980194091797,

--- a/catalogs/lumi/catalog/IFS-NEMO/a1al.yaml
+++ b/catalogs/lumi/catalog/IFS-NEMO/a1al.yaml
@@ -27,8 +27,8 @@ sources:
     description: hourly data on native grid .
     driver: gsv
     metadata: &metadata-default
-      fdb_home: /users/lrb_465000454_fdb/native
-      fdb_path: /users/lrb_465000454_fdb/native/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt/native
+      fdb_path: /appl/local/climatedt/native/etc/fdb/config.yaml
       eccodes_path: /projappl/project_465000454/jvonhar/aqua/eccodes/eccodes-2.32.5/definitions
       variables: [78, 79, 134, 137, 141, 148, 151, 159, 164, 165, 166, 167, 168, 186,
         187, 188, 235, 260048, 8, 9, 144, 146, 147, 169, 175, 176, 177, 178, 179,
@@ -122,8 +122,8 @@ sources:
         resolution: standard
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       source_grid_name: hpz7-nested
 
   hourly-hpz7-atm3d:
@@ -141,8 +141,8 @@ sources:
           700, 850, 925, 1000]
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 700,
         850, 925, 1000]
       variables: [60, 129, 130, 131, 132, 133, 135, 157, 246]
@@ -162,8 +162,8 @@ sources:
         levtype: o2d
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       variables: [263000, 263001, 263003, 263004, 263008, 263009, 263021, 263022,
         263100, 263101, 263121, 263122, 263124]
       source_grid_name: nemo-eORCA025-hpz7-nested
@@ -187,8 +187,8 @@ sources:
           73, 74, 75]
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       levels: [0.5057600140571594, 1.5558552742004395, 2.6676816940307617, 3.8562798500061035,
         5.140361309051514, 6.543033599853516, 8.09251880645752, 9.822750091552734,
         11.773679733276367, 13.99103832244873, 16.52532196044922, 19.42980194091797,

--- a/catalogs/lumi/catalog/IFS-NEMO/ssp370.yaml
+++ b/catalogs/lumi/catalog/IFS-NEMO/ssp370.yaml
@@ -27,8 +27,8 @@ sources:
     description: hourly data on native grid Tco2559 (about 5km).
     driver: gsv
     metadata: &metadata-default
-      fdb_home: /users/lrb_465000454_fdb/native
-      fdb_path: /users/lrb_465000454_fdb/native/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt/native
+      fdb_path: /appl/local/climatedt/native/etc/fdb/config.yaml
       eccodes_path: /projappl/project_465000454/jvonhar/aqua/eccodes/eccodes-2.32.5/definitions
       variables: [78, 79, 134, 137, 141, 148, 151, 159, 164, 165, 166, 167, 168, 186,
         187, 188, 235, 260048, 8, 9, 144, 146, 147, 169, 175, 176, 177, 178, 179,
@@ -50,8 +50,8 @@ sources:
           700, 850, 925, 1000]
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb/native
-      fdb_path: /users/lrb_465000454_fdb/native/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt/native
+      fdb_path: /appl/local/climatedt/native/etc/fdb/config.yaml
       levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 700,
         850, 925, 1000]
       variables: [60, 129, 130, 131, 132, 133, 135, 157, 246]
@@ -67,8 +67,8 @@ sources:
         resolution: standard
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       source_grid_name: hpz7-nested
 
   hourly-hpz7-atm3d:
@@ -87,8 +87,8 @@ sources:
           700, 850, 925, 1000]
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 700,
         850, 925, 1000]
       variables: [60, 129, 130, 131, 132, 133, 135, 157, 246]
@@ -105,10 +105,10 @@ sources:
         resolution: high
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
-      fdb_home_bridge: /users/lrb_465000454_fdb/databridge
-      fdb_path_bridge: /users/lrb_465000454_fdb/databridge/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
+      fdb_home_bridge: /appl/local/climatedt/databridge
+      fdb_path_bridge: /appl/local/climatedt/databridge/etc/fdb/config.yaml
       source_grid_name: hpz10-nested
 
   hourly-hpz10-atm3d:
@@ -129,10 +129,10 @@ sources:
           700, 850, 925, 1000]
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
-      fdb_home_bridge: /users/lrb_465000454_fdb/databridge
-      fdb_path_bridge: /users/lrb_465000454_fdb/databridge/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
+      fdb_home_bridge: /appl/local/climatedt/databridge
+      fdb_path_bridge: /appl/local/climatedt/databridge/etc/fdb/config.yaml
       levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 700,
         850, 925, 1000]
       variables: [60, 129, 130, 131, 132, 133, 135, 157, 246]
@@ -148,8 +148,8 @@ sources:
         resolution: standard
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb/latlon
-      fdb_path: /users/lrb_465000454_fdb/latlon/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt/latlon
+      fdb_path: /appl/local/climatedt/latlon/etc/fdb/config.yaml
       source_grid_name: era5-r025
 
   hourly-r025-atm3d:
@@ -167,8 +167,8 @@ sources:
           700, 850, 925, 1000]
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb/latlon
-      fdb_path: /users/lrb_465000454_fdb/latlon/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt/latlon
+      fdb_path: /appl/local/climatedt/latlon/etc/fdb/config.yaml
       source_grid_name: era5-r025
       levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 700,
         850, 925, 1000]
@@ -188,8 +188,8 @@ sources:
         levtype: o2d
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb/native
-      fdb_path: /users/lrb_465000454_fdb/native/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt/native
+      fdb_path: /appl/local/climatedt/native/etc/fdb/config.yaml
       variables: [263000, 263001, 263003, 263004, 263008, 263009, 263021, 263022,
         263100, 263101, 263121, 263122, 263124]
       source_grid_name: eORCA12-2d
@@ -213,8 +213,8 @@ sources:
           73, 74, 75]
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb/native
-      fdb_path: /users/lrb_465000454_fdb/native/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt/native
+      fdb_path: /appl/local/climatedt/native/etc/fdb/config.yaml
       levels: [0.5057600140571594, 1.5558552742004395, 2.6676816940307617, 3.8562798500061035,
         5.140361309051514, 6.543033599853516, 8.09251880645752, 9.822750091552734,
         11.773679733276367, 13.99103832244873, 16.52532196044922, 19.42980194091797,
@@ -251,8 +251,8 @@ sources:
         levtype: o2d
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb/latlon
-      fdb_path: /users/lrb_465000454_fdb/latlon/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt/latlon
+      fdb_path: /appl/local/climatedt/latlon/etc/fdb/config.yaml
       variables: [263000, 263001, 263003, 263004, 263008, 263009, 263021, 263022,
         263100, 263101, 263121, 263122, 263124]
       source_grid_name: nemo-multiIO-r025
@@ -276,8 +276,8 @@ sources:
           73, 74, 75]
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb/latlon
-      fdb_path: /users/lrb_465000454_fdb/latlon/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt/latlon
+      fdb_path: /appl/local/climatedt/latlon/etc/fdb/config.yaml
       levels: [0.5057600140571594, 1.5558552742004395, 2.6676816940307617, 3.8562798500061035,
         5.140361309051514, 6.543033599853516, 8.09251880645752, 9.822750091552734,
         11.773679733276367, 13.99103832244873, 16.52532196044922, 19.42980194091797,
@@ -314,8 +314,8 @@ sources:
         levtype: o2d
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       variables: [263000, 263001, 263003, 263004, 263008, 263009, 263021, 263022,
         263100, 263101, 263121, 263122, 263124]
       source_grid_name: nemo-eORCA12-hpz7-nested
@@ -335,10 +335,10 @@ sources:
         levtype: o2d
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
-      fdb_home_bridge: /users/lrb_465000454_fdb/databridge
-      fdb_path_bridge: /users/lrb_465000454_fdb/databridge/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
+      fdb_home_bridge: /appl/local/climatedt/databridge
+      fdb_path_bridge: /appl/local/climatedt/databridge/etc/fdb/config.yaml
       variables: [263000, 263001, 263003, 263004, 263008, 263009, 263021, 263022,
         263100, 263101, 263121, 263122, 263124]
       source_grid_name: nemo-eORCA12-hpz10-nested
@@ -363,8 +363,8 @@ sources:
           73, 74, 75]
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
       levels: [0.5057600140571594, 1.5558552742004395, 2.6676816940307617, 3.8562798500061035,
         5.140361309051514, 6.543033599853516, 8.09251880645752, 9.822750091552734,
         11.773679733276367, 13.99103832244873, 16.52532196044922, 19.42980194091797,
@@ -408,10 +408,10 @@ sources:
           73, 74, 75]
     metadata:
       <<: *metadata-default
-      fdb_home: /users/lrb_465000454_fdb
-      fdb_path: /users/lrb_465000454_fdb/etc/fdb/config.yaml
-      fdb_home_bridge: /users/lrb_465000454_fdb/databridge
-      fdb_path_bridge: /users/lrb_465000454_fdb/databridge/etc/fdb/config.yaml
+      fdb_home: /appl/local/climatedt
+      fdb_path: /appl/local/climatedt/etc/fdb/config.yaml
+      fdb_home_bridge: /appl/local/climatedt/databridge
+      fdb_path_bridge: /appl/local/climatedt/databridge/etc/fdb/config.yaml
       levels: [0.5057600140571594, 1.5558552742004395, 2.6676816940307617, 3.8562798500061035,
         5.140361309051514, 6.543033599853516, 8.09251880645752, 9.822750091552734,
         11.773679733276367, 13.99103832244873, 16.52532196044922, 19.42980194091797,


### PR DESCRIPTION
This is a hotfix which substitutes `/appl/local/climatedt` to all instances of `/users/lrb_465000454_fdb` in the lumi catalog. This allows for now the catalogues to work while #8 is still in development. I suggest to merge this asap and then merge the main into #8.