### PR TITLE
Replacing deprecated aggregation keyword with chunks

### DIFF
--- a/catalogs/climatedt-phase1/catalog/IFS-FESOM/story-2017-T2K.yaml
+++ b/catalogs/climatedt-phase1/catalog/IFS-FESOM/story-2017-T2K.yaml
@@ -42,7 +42,7 @@ sources:
     description: hourly 3D atmospheric data on healpix grid (zoom=7, h128).
     args:
       <<: *args-default
-      aggregation: 6h
+      chunks: 6H
       request:
         <<: *request-default
         param: 129
@@ -61,7 +61,7 @@ sources:
     description: hourly 3D atmospheric data on healpix grid (zoom=9, h512).
     args:
       <<: *args-default
-      aggregation: 6h
+      chunks: 6H
       request:
         <<: *request-default
         param: 129
@@ -76,7 +76,7 @@ sources:
     description: hourly 3D atmospheric data on healpix grid (zoom=9, h512).
     args:
       <<: *args-default
-      aggregation: 6h
+      chunks: 6H
       request:
         <<: *request-default
         param: 129
@@ -114,8 +114,7 @@ sources:
     description: daily 3D oceanic data on healpix grid (zoom=7, h128).
     args:
       <<: *args-default
-      aggregation: D
-      chunks: MS
+      chunks: D
       savefreq: D
       request:
         <<: *request-default
@@ -159,8 +158,7 @@ sources:
     description: daily 3D oceanic data on healpix grid (zoom=9, h512).
     args:
       <<: *args-default
-      aggregation: D
-      chunks: MS
+      chunks: D
       savefreq: D
       request:
         <<: *request-default
@@ -187,7 +185,7 @@ sources:
     description: hourly 2D atmospheric data on native grid TCo1279 (about 10km).
     args:
       <<: *args-default
-      aggregation: 6H
+      chunks: 6H
       request:
         <<: *request-default
         resolution: high
@@ -201,7 +199,7 @@ sources:
     description: hourly 3D atmospheric data on native grid TCo1279 (about 10km).
     args:
       <<: *args-default
-      aggregation: H
+      chunks: H
       request:
         <<: *request-default
         levtype: pl
@@ -220,7 +218,7 @@ sources:
 #     description: hourly 2D ocean data on native grid ng5 (about 10km).
 #     args:
 #       <<: *args-default
-#       aggregation: 6H
+#       chunks: 6H
 #       request:
 #         <<: *request-default
 # #        param: 131
@@ -238,7 +236,7 @@ sources:
 #     description: hourly 3D oceanic data on native grid ng5 (about 10km).
 #     args:
 #       <<: *args-default
-#       aggregation: 6H
+#       chunks: 6H
 #       request:
 #         <<: *request-default
 # #        param: 131

--- a/catalogs/climatedt-phase1/catalog/IFS-FESOM/story-2017-control.yaml
+++ b/catalogs/climatedt-phase1/catalog/IFS-FESOM/story-2017-control.yaml
@@ -22,7 +22,7 @@ sources:
       data_start_date: 20170101T0000
       data_end_date: 20231231T2300
       bridge_end_date: complete
-      aggregation: D  # Default aggregation / chunk size
+      chunks: D  # Default chunks size
       savefreq: h  # at what frequency are data saved
       timestep: h  # base timestep for step timestyle
       timestyle: date  # variable date or variable step
@@ -42,7 +42,7 @@ sources:
     description: hourly 3D atmospheric data on healpix grid (zoom=7, h128).
     args:
       <<: *args-default
-      aggregation: 6h
+      chunks: 6H
       request:
         <<: *request-default
         param: 129
@@ -75,7 +75,7 @@ sources:
     description: hourly 3D atmospheric data on healpix grid (zoom=9, h512).
     args:
       <<: *args-default
-      aggregation: 6h
+      chunks: 6H
       request:
         <<: *request-default
         param: 129
@@ -95,7 +95,7 @@ sources:
     description: daily 2D oceanic data on healpix grid (zoom=7, h128).
     args:
       <<: *args-default
-      aggregation: MS
+      chunks: MS
       savefreq: D
       request:
         <<: *request-default
@@ -112,7 +112,7 @@ sources:
     description: daily 3D oceanic data on healpix grid (zoom=7, h128).
     args:
       <<: *args-default
-      aggregation: D
+      chunks: D
       savefreq: D
       request:
         <<: *request-default
@@ -139,7 +139,7 @@ sources:
     description: daily 2D oceanic data on healpix grid (zoom=9, h1024).
     args:
       <<: *args-default
-      aggregation: MS
+      chunks: MS
       savefreq: D
       data_start_date: 20180101T0000
       request:
@@ -157,7 +157,7 @@ sources:
     description: daily 3D oceanic data on healpix grid (zoom=9, h1024).
     args:
       <<: *args-default
-      aggregation: D
+      chunks: D
       savefreq: D
       data_start_date: 20180101T0000
       request:
@@ -185,7 +185,7 @@ sources:
     description: hourly 2D atmospheric data on native grid TCo1279 (about 10km).
     args:
       <<: *args-default
-      aggregation: 6H
+      chunks: 6H
       request:
         <<: *request-default
         levtype: sfc
@@ -200,7 +200,7 @@ sources:
     description: hourly 3D atmospheric data on native grid TCo1279 (about 10km).
     args:
       <<: *args-default
-      aggregation: H
+      chunks: H
       request:
         <<: *request-default
         levtype: pl
@@ -220,7 +220,7 @@ sources:
   #   description: hourly 2D ocean data on native grid ng5 (about 10km).
   #   args:
   #     <<: *args-default
-  #     aggregation: 6H
+  #     chunks: 6H
   #     request:
   #       <<: *request-default
   #       levtype: o2d
@@ -239,7 +239,7 @@ sources:
   #   description: hourly 3D oceanic data on native grid ng5 (about 10km).
   #   args:
   #     <<: *args-default
-  #     aggregation: 6H
+  #     chunks: 6H
   #     request:
   #       <<: *request-default
   #       levtype: o3d

--- a/catalogs/climatedt-phase1/catalog/IFS-FESOM/story-2017-historical.yaml
+++ b/catalogs/climatedt-phase1/catalog/IFS-FESOM/story-2017-historical.yaml
@@ -23,7 +23,7 @@ sources:
       data_start_date: 20170101T0000
       data_end_date: 20231231T2300
       bridge_end_date: complete
-      aggregation: D  # Default aggregation / chunk size
+      chunks: D  # Default chunks size
       savefreq: h  # at what frequency are data saved
       timestep: h  # base timestep for step timestyle
       timestyle: date  # variable date or variable step
@@ -44,7 +44,7 @@ sources:
     description: hourly 3D atmospheric data on healpix grid (zoom=7, h128).
     args:
       <<: *args-default
-      aggregation: 6h
+      chunks: 6H
       request:
         <<: *request-default
         param: 129
@@ -63,7 +63,7 @@ sources:
     description: hourly 3D atmospheric data on healpix grid (zoom=9, h512).
     args:
       <<: *args-default
-      aggregation: 6h
+      chunks: 6H
       request:
         <<: *request-default
         param: 129
@@ -78,7 +78,7 @@ sources:
     description: hourly 3D atmospheric data on healpix grid (zoom=9, h512).
     args:
       <<: *args-default
-      aggregation: 6h
+      chunks: 6H
       request:
         <<: *request-default
         param: 129
@@ -99,7 +99,7 @@ sources:
     description: daily 2D oceanic data on healpix grid (zoom=7, h128).
     args:
       <<: *args-default
-      aggregation: MS
+      chunks: MS
       savefreq: D
       request:
         <<: *request-default
@@ -115,7 +115,7 @@ sources:
     description: daily 3D oceanic data on healpix grid (zoom=7, h128).
     args:
       <<: *args-default
-      aggregation: D
+      chunks: D
       savefreq: D
       request:
         <<: *request-default
@@ -141,7 +141,7 @@ sources:
     description: daily 2D oceanic data on healpix grid (zoom=9, h1024).
     args:
       <<: *args-default
-      aggregation: MS
+      chunks: MS
       savefreq: D
       data_start_date: 20180701T0000
       request:
@@ -158,7 +158,7 @@ sources:
     description: daily 3D oceanic data on healpix grid (zoom=9, h1024).
     args:
       <<: *args-default
-      aggregation: D
+      chunks: D
       savefreq: D
       data_start_date: 20180701T0000
       request:
@@ -186,7 +186,7 @@ sources:
     description: hourly 2D atmospheric data on native grid TCo1279 (about 10km).
     args:
       <<: *args-default
-      aggregation: 6H
+      chunks: 6H
       request:
         <<: *request-default
         resolution: high
@@ -200,7 +200,7 @@ sources:
     description: hourly 3D atmospheric data on native grid TCo1279 (about 10km).
     args:
       <<: *args-default
-      aggregation: H
+      chunks: H
       request:
         <<: *request-default
         levtype: pl
@@ -220,7 +220,7 @@ sources:
 #     description: hourly 2D ocean data on native grid ng5 (about 10km).
 #     args:
 #       <<: *args-default
-#       aggregation: 6H
+#       chunks: 6H
 #       request:
 #         <<: *request-default
 # #        param: 131
@@ -238,7 +238,7 @@ sources:
 #     description: hourly 3D oceanic data on native grid ng5 (about 10km).
 #     args:
 #       <<: *args-default
-#       aggregation: 6H
+#       chunks: 6H
 #       request:
 #         <<: *request-default
 # #        param: 131

--- a/catalogs/leonardo/catalog/IFS-FESOM/placeholder.yaml
+++ b/catalogs/leonardo/catalog/IFS-FESOM/placeholder.yaml
@@ -21,7 +21,7 @@ sources:
         step: 0
       data_start_date: 20170101T0000
       data_end_date: auto
-      aggregation: D  # Default aggregation / chunk size
+      chunks: D  # Default chunks size
       savefreq: h  # at what frequency are data saved
       timestep: h  # base timestep for step timestyle
       timestyle: date  # variable date or variable step
@@ -41,7 +41,7 @@ sources:
     description: hourly 3D atmospheric data on healpix grid (zoom=7, h128).
     args:
       <<: *args-default
-      aggregation: 6h
+      chunks: 6H
       request:
         <<: *request-default
         param: 129
@@ -74,7 +74,7 @@ sources:
     description: hourly 3D atmospheric data on healpix grid (zoom=9, h512).
     args:
       <<: *args-default
-      aggregation: 6h
+      chunks: 6H
       request:
         <<: *request-default
         param: 129
@@ -94,7 +94,7 @@ sources:
     description: daily 2D oceanic data on healpix grid (zoom=7, h128).
     args:
       <<: *args-default
-      aggregation: MS
+      chunks: MS
       savefreq: D
       request:
         <<: *request-default
@@ -110,7 +110,7 @@ sources:
     description: daily 3D oceanic data on healpix grid (zoom=7, h128).
     args:
       <<: *args-default
-      aggregation: D
+      chunks: D
       savefreq: D
       request:
         <<: *request-default
@@ -137,7 +137,7 @@ sources:
     description: daily 2D oceanic data on healpix grid (zoom=9, h1024).
     args:
       <<: *args-default
-      aggregation: MS
+      chunks: MS
       savefreq: D
       # data_start_date: 20180101T0000
       request:
@@ -154,7 +154,7 @@ sources:
     description: daily 3D oceanic data on healpix grid (zoom=9, h1024).
     args:
       <<: *args-default
-      aggregation: D
+      chunks: D
       savefreq: D
       data_start_date: 20180101T0000
       request:
@@ -182,7 +182,7 @@ sources:
     description: hourly 2D atmospheric data on native grid TCo1279 (about 10km).
     args:
       <<: *args-default
-      aggregation: 6H
+      chunks: 6H
       request:
         <<: *request-default
         levtype: sfc
@@ -197,7 +197,7 @@ sources:
     description: hourly 3D atmospheric data on native grid TCo1279 (about 10km).
     args:
       <<: *args-default
-      aggregation: H
+      chunks: H
       request:
         <<: *request-default
         levtype: pl

--- a/catalogs/lumi-phase1/catalog/IFS-NEMO/a0xv.yaml
+++ b/catalogs/lumi-phase1/catalog/IFS-NEMO/a0xv.yaml
@@ -19,7 +19,7 @@ sources:
         levtype: sfc
       data_start_date: 19900101T0000
       data_end_date: 20191231T2300
-      aggregation: YS  # Default aggregation / chunk size
+      chunks: YS  # Default chunks size
       savefreq: MS  # at what frequency are data saved
       timestep: MS  # base timestep for step timestyle
       timestyle: yearmonth  # variable date or variable step
@@ -43,7 +43,7 @@ sources:
     description: monthly atmospheric 3D data on regular 1 degree grid (MultIO)
     args:
       <<: *args-default
-      aggregation: MS
+      chunks: MS
       request:
         <<: *request-default
         param: 130
@@ -74,7 +74,7 @@ sources:
   #   description: daily ocean 3D data on healpix zoom=5 grid
   #   args:
   #     <<: *args-default
-  #     aggregation: MS
+  #     chunks: MS
   #     request:
   #       <<: *request-default
   #       resolution: standard

--- a/catalogs/nextgems4/catalog/IFS-FESOM/historical-1990.yaml
+++ b/catalogs/nextgems4/catalog/IFS-FESOM/historical-1990.yaml
@@ -242,7 +242,7 @@ sources:
     args:
       <<: *args-default
       data_start_date: 20000101T0000
-      aggregation: 6h
+      chunks: 6H
       request:
         <<: *request-default
         param: 131
@@ -263,7 +263,7 @@ sources:
     args:
       <<: *args-default
       data_start_date: 20000101T0000
-      aggregation: MS
+      chunks: MS
       savefreq: D
       request:
         <<: *request-default
@@ -283,7 +283,7 @@ sources:
     args:
       <<: *args-default
       data_start_date: 20000101T0000
-      aggregation: D
+      chunks: D
       savefreq: D
       request:
         <<: *request-default
@@ -328,7 +328,7 @@ sources:
     args:
       <<: *args-default
       data_start_date: 20100101T0000
-      aggregation: 6h
+      chunks: 6H
       request:
         <<: *request-default
         param: 131
@@ -349,7 +349,7 @@ sources:
     args:
       <<: *args-default
       data_start_date: 20100101T0000
-      aggregation: MS
+      chunks: MS
       savefreq: D
       request:
         <<: *request-default
@@ -369,7 +369,7 @@ sources:
     args:
       <<: *args-default
       data_start_date: 20100101T0000
-      aggregation: D
+      chunks: D
       savefreq: D
       request:
         <<: *request-default

--- a/catalogs/nextgems4/catalog/IFS-FESOM/ssp370.yaml
+++ b/catalogs/nextgems4/catalog/IFS-FESOM/ssp370.yaml
@@ -22,7 +22,7 @@ sources:
         step: 0
       data_start_date: auto
       data_end_date: auto
-      aggregation: D  # Default aggregation / chunk size
+      chunks: D  # Default chunks size
       savefreq: H  # at what frequency are data saved
       timestep: H  # base timestep for step timestyle
       timestyle: date  # variable date or variable step
@@ -42,7 +42,7 @@ sources:
     description: hourly 3D atmospheric data on native grid (about 5km).
     args:
       <<: *args-default
-      aggregation: 6H
+      chunks: 6H
       request:
         <<: *request-default
         param: 131
@@ -60,7 +60,7 @@ sources:
     description: daily 2D oceanic data on native grid NG5.
     args:
       <<: *args-default
-      aggregation: M
+      chunks: M
       savefreq: D
       request:
         <<: *request-default
@@ -79,7 +79,7 @@ sources:
     description: daily 3D oceanic data on native grid NG5.
     args:
       <<: *args-default
-      aggregation: D
+      chunks: D
       savefreq: D
       request:
         <<: *request-default
@@ -122,7 +122,7 @@ sources:
     description: hourly 3D atmospheric data on healpix grid (zoom=7, h128).
     args:
       <<: *args-default
-      aggregation: 6H
+      chunks: 6H
       request:
         <<: *request-default
         resolution: standard
@@ -143,7 +143,7 @@ sources:
     description: daily 2D oceanic data on healpix grid (zoom=7, h128).
     args:
       <<: *args-default
-      aggregation: MS
+      chunks: MS
       savefreq: D
       data_start_date: 20220501T0000  # OCE data not available before 20210901 and with wrong mask until 20220501 excluded
       request:
@@ -163,7 +163,7 @@ sources:
     description: daily 3D oceanic data on healpix grid (zoom=7, h128).
     args:
       <<: *args-default
-      aggregation: D
+      chunks: D
       savefreq: D
       data_start_date: 20220501T0000  # OCE data not available before 20210901 and with wrong mask until 20220501 excluded
       request:
@@ -208,7 +208,7 @@ sources:
     description: hourly 3D atmospheric data on healpix grid (zoom=9, h512).
     args:
       <<: *args-default
-      aggregation: 6H
+      chunks: 6H
       request:
         <<: *request-default
         resolution: high
@@ -229,7 +229,7 @@ sources:
     description: daily 2D oceanic data on healpix grid (zoom=9, h512).
     args:
       <<: *args-default
-      aggregation: MS
+      chunks: MS
       savefreq: D
       data_start_date: 20220501T0000  # OCE data not available before 20210901 and with wrong mask until 20220501 excluded
       request:
@@ -249,7 +249,7 @@ sources:
     description: daily 3D oceanic data on healpix grid (zoom=9, h512).
     args:
       <<: *args-default
-      aggregation: D
+      chunks: D
       savefreq: D
       data_start_date: 20220501T0000  # OCE data not available before 20210901 and with wrong mask until 20220501 excluded
       request:
@@ -295,7 +295,7 @@ sources:
     description: hourly 3D atmospheric data on regular r025 grid (1440x721).
     args:
       <<: *args-default
-      aggregation: 6H
+      chunks: 6H
       request:
         <<: *request-default
         resolution: standard
@@ -335,7 +335,7 @@ sources:
     args:
       <<: *args-default
       data_start_date: 20300101T0000
-      aggregation: 6H
+      chunks: 6H
       request:
         <<: *request-default
         resolution: standard
@@ -357,7 +357,7 @@ sources:
     args:
       <<: *args-default
       data_start_date: 20300101T0000
-      aggregation: MS
+      chunks: MS
       savefreq: D
       request:
         <<: *request-default
@@ -377,7 +377,7 @@ sources:
     args:
       <<: *args-default
       data_start_date: 20300101T0000
-      aggregation: D
+      chunks: D
       savefreq: D
       request:
         <<: *request-default
@@ -423,7 +423,7 @@ sources:
     args:
       <<: *args-default
       data_start_date: 20350101T0000
-      aggregation: 6H
+      chunks: 6H
       request:
         <<: *request-default
         resolution: standard
@@ -445,7 +445,7 @@ sources:
     args:
       <<: *args-default
       data_start_date: 20350101T0000
-      aggregation: MS
+      chunks: MS
       savefreq: D
       request:
         <<: *request-default
@@ -464,7 +464,7 @@ sources:
     description: daily 3D oceanic data on healpix grid (zoom=7, h128).
     args:
       <<: *args-default
-      aggregation: D
+      chunks: D
       savefreq: D
       data_start_date: 20350101T0000
       request:
@@ -511,7 +511,7 @@ sources:
     args:
       <<: *args-default
       data_start_date: 20400101T0000
-      aggregation: 6H
+      chunks: 6H
       request:
         <<: *request-default
         resolution: standard
@@ -533,7 +533,7 @@ sources:
     args:
       <<: *args-default
       data_start_date: 20400101T0000
-      aggregation: MS
+      chunks: MS
       savefreq: D
       request:
         <<: *request-default
@@ -553,7 +553,7 @@ sources:
     args:
       <<: *args-default
       data_start_date: 20400101T0000
-      aggregation: D
+      chunks: D
       savefreq: D
       request:
         <<: *request-default
@@ -601,7 +601,7 @@ sources:
     args:
       <<: *args-default
       data_start_date: 20300101T0000
-      aggregation: 6H
+      chunks: 6H
       request:
         <<: *request-default
         resolution: high
@@ -623,7 +623,7 @@ sources:
     args:
       <<: *args-default
       data_start_date: 20300101T0000
-      aggregation: MS
+      chunks: MS
       savefreq: D
       request:
         <<: *request-default
@@ -643,7 +643,7 @@ sources:
     args:
       <<: *args-default
       data_start_date: 20300101T0000
-      aggregation: D
+      chunks: D
       savefreq: D
       request:
         <<: *request-default
@@ -689,7 +689,7 @@ sources:
     args:
       <<: *args-default
       data_start_date: 20350101T0000
-      aggregation: 6H
+      chunks: 6H
       request:
         <<: *request-default
         resolution: high
@@ -711,7 +711,7 @@ sources:
     args:
       <<: *args-default
       data_start_date: 20350101T0000
-      aggregation: MS
+      chunks: MS
       savefreq: D
       request:
         <<: *request-default
@@ -731,7 +731,7 @@ sources:
     args:
       <<: *args-default
       data_start_date: 20350101T0000
-      aggregation: D
+      chunks: D
       savefreq: D
       request:
         <<: *request-default
@@ -777,7 +777,7 @@ sources:
     args:
       <<: *args-default
       data_start_date: 20400101T0000
-      aggregation: 6H
+      chunks: 6H
       request:
         <<: *request-default
         resolution: high
@@ -799,7 +799,7 @@ sources:
     args:
       <<: *args-default
       data_start_date: 20400101T0000
-      aggregation: MS
+      chunks: MS
       savefreq: D
       request:
         <<: *request-default
@@ -819,7 +819,7 @@ sources:
     args:
       <<: *args-default
       data_start_date: 20400101T0000
-      aggregation: D
+      chunks: D
       savefreq: D
       request:
         <<: *request-default


### PR DESCRIPTION
## PR description:

replacing `chunks` in the sources still using `aggregation`, keyword not used anymore.

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready" label.

 - [ ] aqua add catalog test is done.
