### PR TITLE
Temperature encoding fix for IFS-FESOM storylines

### DIFF
--- a/catalogs/climatedt-phase1/catalog/IFS-FESOM/story-2017-T2K.yaml
+++ b/catalogs/climatedt-phase1/catalog/IFS-FESOM/story-2017-T2K.yaml
@@ -108,6 +108,7 @@ sources:
       fdb_home: '{{ FDB_PATH }}'
       variables: [263000, 263001, 263002, 263003, 263004, 263100, 263101, 263124]
       source_grid_name: fesom-NG5-hpz7-nested-v2
+      fixer_name: fesom-destine-v1
 
   daily-hpz7-oce3d:
     <<: *base-default
@@ -135,6 +136,7 @@ sources:
         6175]
       variables: [263500, 263501, 263505, 263506, 263507]
       source_grid_name: fesom-NG5-hpz7-nested-3d-v2
+      fixer_name: fesom-destine-v1
 
   daily-hpz9-oce2d:
     <<: *base-default
@@ -152,6 +154,7 @@ sources:
       fdb_home: '{{ FDB_PATH }}'
       variables: [263000, 263001, 263002, 263003, 263004, 263100, 263101, 263124]
       source_grid_name: fesom-NG5-hpz9-nested-v2
+      fixer_name: fesom-destine-v1
 
   daily-hpz9-oce3d:
     <<: *base-default
@@ -179,6 +182,7 @@ sources:
         6175]
       variables: [263500, 263501, 263505, 263506, 263507]
       source_grid_name: fesom-NG5-hpz9-nested-3d-v2
+      fixer_name: fesom-destine-v1
 
   hourly-native-atm2d:
     <<: *base-default
@@ -255,7 +259,8 @@ sources:
 #     2775, 3025, 3275, 3525, 3775, 4025, 4275, 4525, 4775, 5025,
 #     5275, 5525, 5825, 6175]
 #       variables: [263500, 263501, 263505, 263506, 263507]
-#       source_grid_name: ng5-nodes-3dsunnyjal@uan01:/pfs/lustrep3/projappl/project_465000454/ajohn/AQUA/config/machines/lumi/catalog/IFS-FESOM$
+#       source_grid_name: ng5-nodes-3d
+
   lra-r100-monthly:
     driver: netcdf
     description: LRA data monthly at r100
@@ -267,6 +272,8 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: fesom-destine-v1
+
   lra-r100-monthly-zarr:
     driver: zarr
     description: LRA data monthly at r100 reference on zarr
@@ -277,4 +284,4 @@ sources:
       - reference::{{ LRA_PATH }}/IFS-FESOM/story-2017-T2K/r100/monthly/zarr/lra-yearly-files.json
     metadata:
       source_grid_name: lon-lat
-    fixer_name: false
+      fixer_name: fesom-destine-v1

--- a/catalogs/climatedt-phase1/catalog/IFS-FESOM/story-2017-control.yaml
+++ b/catalogs/climatedt-phase1/catalog/IFS-FESOM/story-2017-control.yaml
@@ -106,6 +106,7 @@ sources:
       <<: *metadata-default
       variables: [263000, 263001, 263002, 263003, 263004, 263100, 263101, 263124]
       source_grid_name: fesom-NG5-hpz7-nested-v2
+      fixer_name: fesom-destine-v1
 
   daily-hpz7-oce3d:
     <<: *base-default
@@ -133,6 +134,7 @@ sources:
         6175]
       variables: [263500, 263501, 263505, 263506, 263507]
       source_grid_name: fesom-NG5-hpz7-nested-3d-v2
+      fixer_name: fesom-destine-v1
 
   daily-hpz9-oce2d:
     <<: *base-default
@@ -151,6 +153,7 @@ sources:
       <<: *metadata-default
       variables: [263000, 263001, 263002, 263003, 263004, 263100, 263101, 263124]
       source_grid_name: fesom-NG5-hpz9-nested-v2
+      fixer_name: fesom-destine-v1
 
   daily-hpz9-oce3d:
     <<: *base-default
@@ -179,6 +182,7 @@ sources:
         6175]
       variables: [263500, 263501, 263505, 263506, 263507]
       source_grid_name: fesom-NG5-hpz9-nested-3d-v2
+      fixer_name: fesom-destine-v1
 
   hourly-native-atm2d:
     <<: *base-default
@@ -258,6 +262,7 @@ sources:
   #   5275, 5525, 5825, 6175]
   #     variables: [263500, 263501, 263505, 263506, 263507]
   #     source_grid_name: ng5-nodes-3d
+
   lra-r100-monthly:
     driver: netcdf
     description: LRA data monthly at r100
@@ -270,3 +275,4 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: fesom-destine-v1

--- a/catalogs/climatedt-phase1/catalog/IFS-FESOM/story-2017-historical.yaml
+++ b/catalogs/climatedt-phase1/catalog/IFS-FESOM/story-2017-historical.yaml
@@ -109,6 +109,7 @@ sources:
       <<: *metadata-default
       variables: [263000, 263001, 263002, 263003, 263004, 263100, 263101, 263124]
       source_grid_name: fesom-NG5-hpz7-nested-v2
+      fixer_name: fesom-destine-v1
 
   daily-hpz7-oce3d:
     <<: *base-default
@@ -135,6 +136,7 @@ sources:
         6175]
       variables: [263500, 263501, 263505, 263506, 263507]
       source_grid_name: fesom-NG5-hpz7-nested-3d-v2
+      fixer_name: fesom-destine-v1
 
   daily-hpz9-oce2d:
     <<: *base-default
@@ -152,6 +154,7 @@ sources:
       <<: *metadata-default
       variables: [263000, 263001, 263002, 263003, 263004, 263100, 263101, 263124]
       source_grid_name: fesom-NG5-hpz9-nested-v2
+      fixer_name: fesom-destine-v1
 
   daily-hpz9-oce3d:
     <<: *base-default
@@ -180,6 +183,7 @@ sources:
         6175]
       variables: [263500, 263501, 263505, 263506, 263507]
       source_grid_name: fesom-NG5-hpz9-nested-3d-v2
+      fixer_name: fesom-destine-v1
 
   hourly-native-atm2d:
     <<: *base-default


### PR DESCRIPTION
## PR description:

The PR fixes the ocean entries for the IFS-FESOM storylines and fixes the LRA for the control and T2K.
The quantities affected where avg_tos and avg_thetao, wrongly encoded as K but with °C values.
The LRA for avg_tos and avg_siconc has to be gereated for IFS-FESOM historical storylines.
