### PR TITLE
Hotfix for IFS-NEMO in lumi-phase1 catalogue

### DIFF
--- a/catalogs/lumi-phase1/catalog/IFS-NEMO/main.yaml
+++ b/catalogs/lumi-phase1/catalog/IFS-NEMO/main.yaml
@@ -23,6 +23,7 @@ sources:
     description: FDB IFS-NEMO tco399-eORCA025 SSP3-7.0 run
     driver: yaml_file_cat
     args:
+      path: '{{CATALOG_DIR}}/a1al.yaml'
   a16z:
     description: FDB IFS-NEMO tco399-eORCA025 1990 control run
     driver: yaml_file_cat


### PR DESCRIPTION
## PR description:

This hotfix fixes the lumi-phase1/IFS-NEMO catalogue which was broken #72.

Issues closed by this pull request:

Close #74

Since it is a hotfix, no CHANGELOG necessary.