### PR TITLE
adding lumi-operational to lumi-phase2

### DIFF
--- a/catalogs/lumi-phase2/machine.yaml
+++ b/catalogs/lumi-phase2/machine.yaml
@@ -13,5 +13,5 @@ lumi-operational:
     weights: /scratch/project_462000560/trial_run/data/AQUA/weights
     areas: /scratch/project_462000560/trial_run/data/AQUA/areas
   intake:
-    LRA_PATH: /scratch/project_462000560/lrb_462000560_suite/a1sm/out/LRA/fc0/lumi-phase2/
+    LRA_PATH: null
     ECCODES_PATH: /pfs/lustrep1/projappl/project_462000560/software/eccodes/eccodes_2.36.0/definitions


### PR DESCRIPTION
## PR description:
Adding lumi-operational to lumi-phase2 to enable AQUA to find data in trial run project.

## Issues closed by this pull request:

Close #80 

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready" label.

 - [ ] General README is updated if a new catalog is added.
 - [ ] aqua add catalog test is done.
 - [ ] Fixes are added to AQUA if new fixes are needed.
 - [ ] Grids are added to AQUA if new grids are needed.
 - [ ] Specific catalog README file is updated or added if needed (note of caution, errata, work to be done, etc.).
