### PR TITLE
fix to the right fdb path for storylines native

### DIFF
--- a/catalogs/climatedt-phase1/catalog/IFS-FESOM/story-2017-T2K.yaml
+++ b/catalogs/climatedt-phase1/catalog/IFS-FESOM/story-2017-T2K.yaml
@@ -210,6 +210,7 @@ sources:
       request:
         <<: *request-default
         levtype: pl
+        resolution: high  
         levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600,
           700, 850, 925, 1000]
     metadata:

--- a/catalogs/climatedt-phase1/catalog/IFS-FESOM/story-2017-control.yaml
+++ b/catalogs/climatedt-phase1/catalog/IFS-FESOM/story-2017-control.yaml
@@ -211,6 +211,7 @@ sources:
       data_start_date: 20180101T0000
       request:
         <<: *request-default
+        resolution: high  
         levtype: pl
         levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600,
           700, 850, 925, 1000]

--- a/catalogs/climatedt-phase1/catalog/IFS-FESOM/story-2017-historical.yaml
+++ b/catalogs/climatedt-phase1/catalog/IFS-FESOM/story-2017-historical.yaml
@@ -212,6 +212,7 @@ sources:
       request:
         <<: *request-default
         levtype: pl
+        resolution: high  
         levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600,
           700, 850, 925, 1000]
     metadata:


### PR DESCRIPTION
## PR description:

As per title, this should fix the container crash experienced in https://github.com/DestinE-Climate-DT/AQUA/issues/1384
Still not working as it should though, we are no longer getting the segfault but still 

```
gsv.exceptions.MissingGSVMessageError: Could not find any GRIB message matching request {'class': 'd1', 'dataset': 'climate-dt', 'activity': 'story-nudging', 'experiment': 'cont', 'generation': 1, 'model': 'IFS-FESOM', 'realization': 1, 'resolution': 'standard', 'expver': '0001', 'type': 'fc', 'stream': 'clte', 'date': ['20170101'], 'time': ['0000'], 'param': [167], 'levtype': 'sfc', 'step': ['0']}.
```

## Issues closed by this pull request:

Close 

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready" label.

 - [ ] General README is updated if a new catalog is added.
 - [ ] aqua add catalog test is done.
 - [ ] Fixes are added to AQUA if new fixes are needed.
 - [ ] Grids are added to AQUA if new grids are needed.
 - [ ] Specific catalog README file is updated or added if needed (note of caution, errata, work to be done, etc.).
