### PR TITLE
Correct folder structure for eccodes

### DIFF
--- a/catalogs/climatedt-phase1/catalog/IFS-FESOM/control-1990.yaml
+++ b/catalogs/climatedt-phase1/catalog/IFS-FESOM/control-1990.yaml
@@ -29,7 +29,7 @@ sources:
     driver: gsv
     metadata:
       fdb_home: '{{ FDB_PATH }}/healpix'
-      eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/eccodes/definitions'
+      eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/definitions'
       variables: [8, 9, 78, 79, 134, 137, 141, 144, 146, 147, 148, 151, 159, 164,
         165, 166, 167, 168, 169, 175, 176, 177, 178, 179, 180, 181, 182, 186, 187,
         188, 212, 228, 235, 260048]
@@ -65,7 +65,7 @@ sources:
     driver: gsv
     metadata:
       fdb_home: '{{ FDB_PATH }}/healpix'
-      eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/eccodes/definitions'
+      eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/definitions'
       variables: [8, 9, 78, 79, 134, 137, 141, 144, 146, 147, 148, 151, 159, 164,
         165, 166, 167, 168, 169, 175, 176, 177, 178, 179, 180, 181, 182, 186, 187,
         188, 212, 228, 235, 260048]
@@ -103,7 +103,7 @@ sources:
     driver: gsv
     metadata:
       fdb_home: '{{ FDB_PATH }}/healpix'
-      eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/eccodes/definitions'
+      eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/definitions'
       levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 700,
         850, 925, 1000]
       variables: [60, 129, 130, 131, 132, 133, 135, 157, 246]
@@ -141,7 +141,7 @@ sources:
     driver: gsv
     metadata:
       fdb_home: '{{ FDB_PATH }}/healpix'
-      eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/eccodes/definitions'
+      eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/definitions'
       levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 700,
         850, 925, 1000]
       variables: [60, 129, 130, 131, 132, 133, 135, 157, 246]
@@ -178,7 +178,7 @@ sources:
     driver: gsv
     metadata:
       fdb_home: '{{ FDB_PATH }}/healpix'
-      eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/eccodes/definitions'
+      eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/definitions'
       variables: [263000, 263001, 263002, 263003, 263004, 263100, 263101, 263124]
       source_grid_name: fesom-NG5-hpz9-nested-v2
       fixer_name: fesom-destine-v1
@@ -213,7 +213,7 @@ sources:
     driver: gsv
     metadata:
       fdb_home: '{{ FDB_PATH }}/healpix'
-      eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/eccodes/definitions'
+      eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/definitions'
       variables: [263000, 263001, 263002, 263003, 263004, 263100, 263101, 263124]
       source_grid_name: fesom-NG5-hpz7-nested-v2
       fixer_name: fesom-destine-v1
@@ -252,7 +252,7 @@ sources:
     driver: gsv
     metadata:
       fdb_home: '{{ FDB_PATH }}/healpix'
-      eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/eccodes/definitions'
+      eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/definitions'
       levels: [2.5, 7.5, 12.5, 17.5, 22.5, 27.5, 32.5, 37.5, 42.5, 47.5, 52.5, 57.5,
         62.5, 67.5, 72.5, 77.5, 82.5, 87.5, 92.5, 97.5, 105, 115, 125, 135, 145, 155,
         165, 175, 185, 195, 210, 230, 250, 270, 290, 320, 360, 400, 440, 480, 520,
@@ -297,7 +297,7 @@ sources:
     driver: gsv
     metadata:
       fdb_home: '{{ FDB_PATH }}/healpix'
-      eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/eccodes/definitions'
+      eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/definitions'
       levels: [2.5, 7.5, 12.5, 17.5, 22.5, 27.5, 32.5, 37.5, 42.5, 47.5, 52.5, 57.5,
         62.5, 67.5, 72.5, 77.5, 82.5, 87.5, 92.5, 97.5, 105, 115, 125, 135, 145, 155,
         165, 175, 185, 195, 210, 230, 250, 270, 290, 320, 360, 400, 440, 480, 520,

--- a/catalogs/climatedt-phase1/catalog/IFS-FESOM/ssp370.yaml
+++ b/catalogs/climatedt-phase1/catalog/IFS-FESOM/ssp370.yaml
@@ -29,7 +29,7 @@ sources:
     driver: gsv
     metadata:
         fdb_home: '{{ FDB_PATH }}/healpix'
-        eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/eccodes/definitions'
+        eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/definitions'
         variables: [8, 9, 78, 79, 134, 137, 141, 144, 146, 147, 148, 151, 159, 164, 165, 166, 167, 168, 169, 175, 176, 177, 178, 179, 180, 181, 182, 186, 187, 188, 212, 228, 235, 260048]
         source_grid_name: hpz10-nested
         fixer_name: ifs-destine-v1
@@ -64,7 +64,7 @@ sources:
     driver: gsv
     metadata:
         fdb_home: '{{ FDB_PATH }}/healpix'
-        eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/eccodes/definitions'
+        eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/definitions'
         variables: [8, 9, 78, 79, 134, 137, 141, 144, 146, 147, 148, 151, 159, 164, 165, 166, 167, 168, 169, 175, 176, 177, 178, 179, 180, 181, 182, 186, 187, 188, 212, 228, 235, 260048]
         source_grid_name: hpz7-nested
         fixer_name: ifs-destine-v1
@@ -99,7 +99,7 @@ sources:
     driver: gsv
     metadata:
         fdb_home: '{{ FDB_PATH }}/healpix'
-        eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/eccodes/definitions'
+        eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/definitions'
         levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 700, 850, 925, 1000]
         variables: [60, 129, 130, 131, 132, 133, 135, 157, 246]
         source_grid_name: hpz10-nested
@@ -136,7 +136,7 @@ sources:
     driver: gsv
     metadata:
         fdb_home: '{{ FDB_PATH }}/healpix'
-        eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/eccodes/definitions'
+        eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/definitions'
         levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 700, 850, 925, 1000]
         variables: [60, 129, 130, 131, 132, 133, 135, 157, 246]
         source_grid_name: hpz7-nested
@@ -172,7 +172,7 @@ sources:
     driver: gsv
     metadata:
         fdb_home: '{{ FDB_PATH }}/healpix'
-        eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/eccodes/definitions'
+        eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/definitions'
         variables: [263000, 263001, 263002, 263003, 263004, 263100, 263101, 263124]
         source_grid_name: fesom-NG5-hpz10-nested-v2
         fixer_name: fesom-destine-v1
@@ -207,7 +207,7 @@ sources:
     driver: gsv
     metadata:
         fdb_home: '{{ FDB_PATH }}/healpix'
-        eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/eccodes/definitions'
+        eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/definitions'
         variables: [263000, 263001, 263002, 263003, 263004, 263100, 263101, 263124]
         source_grid_name: fesom-NG5-hpz7-nested-v2
         fixer_name: fesom-destine-v1
@@ -246,7 +246,7 @@ sources:
     driver: gsv
     metadata:
         fdb_home: "{{ FDB_PATH }}/healpix"
-        eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/eccodes/definitions'
+        eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/definitions'
         levels: [2.5, 7.5, 12.5, 17.5, 22.5, 27.5, 32.5, 37.5, 42.5, 47.5, 52.5, 57.5, 62.5, 67.5,
                  72.5, 77.5, 82.5, 87.5, 92.5, 97.5, 105, 115, 125, 135, 145, 155, 165, 175, 185,
                  195, 210, 230, 250, 270, 290, 320, 360, 400, 440, 480, 520, 560, 600, 640, 710, 810,
@@ -290,7 +290,7 @@ sources:
     driver: gsv
     metadata:
         fdb_home: "{{ FDB_PATH }}/healpix"
-        eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/eccodes/definitions'
+        eccodes_path: '{{ ECCODES_PATH }}/eccodes2.35.1/definitions'
         levels: [2.5, 7.5, 12.5, 17.5, 22.5, 27.5, 32.5, 37.5, 42.5, 47.5, 52.5, 57.5, 62.5, 67.5, 72.5,
                  77.5, 82.5, 87.5, 92.5, 97.5, 105, 115, 125, 135, 145, 155, 165, 175, 185, 195, 210, 230,
                  250, 270, 290, 320, 360, 400, 440, 480, 520, 560, 600, 640, 710, 810, 950, 1110, 1255,


### PR DESCRIPTION
## PR description:

The eccodes folder for eccodes 2.35.1 on MN5 was wrong.
This PR fixes the path, but I didn't modify the path on MN5 yet.

I'm asking for a green light here from @ainagaya and @ghosh97 that I know are using the production run that uses this eccodes version. Please try this branch and modify the path first and then give me a feedback so that I can merge this PR.