### PR TITLE
fixer_name: False for LRA sources (temporary)

### DIFF
--- a/catalogs/climatedt-phase1/catalog/IFS-FESOM/control-1990.yaml
+++ b/catalogs/climatedt-phase1/catalog/IFS-FESOM/control-1990.yaml
@@ -463,3 +463,4 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False

--- a/catalogs/climatedt-phase1/catalog/IFS-FESOM/ssp370.yaml
+++ b/catalogs/climatedt-phase1/catalog/IFS-FESOM/ssp370.yaml
@@ -456,3 +456,4 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False

--- a/catalogs/climatedt-phase1/catalog/IFS-FESOM/story-2017-historical.yaml
+++ b/catalogs/climatedt-phase1/catalog/IFS-FESOM/story-2017-historical.yaml
@@ -279,3 +279,4 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False

--- a/catalogs/climatedt-phase1/catalog/IFS-NEMO/control-1990.yaml
+++ b/catalogs/climatedt-phase1/catalog/IFS-NEMO/control-1990.yaml
@@ -131,3 +131,4 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False

--- a/catalogs/climatedt-phase1/catalog/IFS-NEMO/historical-1990.yaml
+++ b/catalogs/climatedt-phase1/catalog/IFS-NEMO/historical-1990.yaml
@@ -411,6 +411,7 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False
   lra-r100-daily:
     driver: netcdf
     description: LRA data daily at r100
@@ -423,3 +424,4 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False

--- a/catalogs/climatedt-phase1/catalog/IFS-NEMO/ssp370.yaml
+++ b/catalogs/climatedt-phase1/catalog/IFS-NEMO/ssp370.yaml
@@ -316,6 +316,7 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False
 
 # LEGACY of native entry
   # hourly-native-atm3d:

--- a/catalogs/levante/catalog/IFS/control-1950-devcon.yaml
+++ b/catalogs/levante/catalog/IFS/control-1950-devcon.yaml
@@ -9,3 +9,4 @@ sources:
         decode_times: true
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False

--- a/catalogs/levante/catalog/IFS/historical-1990-devcon.yaml
+++ b/catalogs/levante/catalog/IFS/historical-1990-devcon.yaml
@@ -8,3 +8,4 @@ sources:
       xarray_kwargs:
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False

--- a/catalogs/lumi-phase1/catalog/IFS-NEMO/a0fe.yaml
+++ b/catalogs/lumi-phase1/catalog/IFS-NEMO/a0fe.yaml
@@ -9,3 +9,4 @@ sources:
         decode_times: true
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False

--- a/catalogs/lumi-phase1/catalog/IFS-NEMO/a0gg.yaml
+++ b/catalogs/lumi-phase1/catalog/IFS-NEMO/a0gg.yaml
@@ -318,3 +318,4 @@ sources:
         decode_times: true
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False

--- a/catalogs/lumi-phase1/catalog/IFS-NEMO/a0jp.yaml
+++ b/catalogs/lumi-phase1/catalog/IFS-NEMO/a0jp.yaml
@@ -319,3 +319,4 @@ sources:
         decode_times: true
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False

--- a/catalogs/lumi-phase1/catalog/IFS-NEMO/a16z.yaml
+++ b/catalogs/lumi-phase1/catalog/IFS-NEMO/a16z.yaml
@@ -10,3 +10,4 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False

--- a/catalogs/lumi-phase1/catalog/IFS-NEMO/a17r.yaml
+++ b/catalogs/lumi-phase1/catalog/IFS-NEMO/a17r.yaml
@@ -218,3 +218,4 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False

--- a/catalogs/lumi-phase1/catalog/IFS-NEMO/a18j.yaml
+++ b/catalogs/lumi-phase1/catalog/IFS-NEMO/a18j.yaml
@@ -10,3 +10,4 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False

--- a/catalogs/lumi-phase1/catalog/IFS-NEMO/a1al.yaml
+++ b/catalogs/lumi-phase1/catalog/IFS-NEMO/a1al.yaml
@@ -10,3 +10,4 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False

--- a/catalogs/lumi-phase1/catalog/IFS-NEMO/control-1950-dev.yaml
+++ b/catalogs/lumi-phase1/catalog/IFS-NEMO/control-1950-dev.yaml
@@ -150,6 +150,7 @@ sources:
     description: LRA data monthly at r100
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False
     args:
       urlpath: '{{ LRA_DEV }}/IFS/control-1950-devcon/r100/monthly/*control-1950-devcon_r100_monthly_????.nc'
       chunks: {}

--- a/catalogs/lumi-phase1/catalog/IFS-NEMO/historical-1990-dev.yaml
+++ b/catalogs/lumi-phase1/catalog/IFS-NEMO/historical-1990-dev.yaml
@@ -151,6 +151,7 @@ sources:
     description: LRA data monthly at r100
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False
     args:
       urlpath: '{{ LRA_DEV }}/IFS/historical-1990-devcon/r100/monthly/*historical-1990-devcon_r100_monthly_????.nc'
       chunks: {}

--- a/catalogs/lumi-phase1/catalog/IFS-NEMO/spinup-1990-fracice.yaml
+++ b/catalogs/lumi-phase1/catalog/IFS-NEMO/spinup-1990-fracice.yaml
@@ -145,3 +145,4 @@ sources:
         decode_times: true
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False

--- a/catalogs/lumi-phase2/catalog/IFS-NEMO/hs3l-control-1990.yaml
+++ b/catalogs/lumi-phase2/catalog/IFS-NEMO/hs3l-control-1990.yaml
@@ -63,4 +63,5 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False
 

--- a/catalogs/lumi-phase2/catalog/IFS-NEMO/hs3l-historical-1990.yaml
+++ b/catalogs/lumi-phase2/catalog/IFS-NEMO/hs3l-historical-1990.yaml
@@ -63,6 +63,7 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False
 
   lra-r100-monthly-zarr:
     driver: zarr
@@ -74,4 +75,4 @@ sources:
       - reference::{{ LRA_PATH }}/IFS-NEMO/hs3l-historical-1990/r100/monthly/zarr/lra-yearly-files.json
     metadata:
       source_grid_name: lon-lat
-    fixer_name: false
+      fixer_name: false

--- a/catalogs/lumi-phase2/catalog/IFS-NEMO/if8s.yaml
+++ b/catalogs/lumi-phase2/catalog/IFS-NEMO/if8s.yaml
@@ -63,4 +63,5 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False
 

--- a/catalogs/lumi-phase2/catalog/IFS-NEMO/ifca.yaml
+++ b/catalogs/lumi-phase2/catalog/IFS-NEMO/ifca.yaml
@@ -63,4 +63,5 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False
 

--- a/catalogs/lumi-phase2/catalog/IFS-NEMO/igsg.yaml
+++ b/catalogs/lumi-phase2/catalog/IFS-NEMO/igsg.yaml
@@ -45,3 +45,4 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False

--- a/catalogs/mn5-phase2/catalog/IFS-NEMO/a1bc.yaml
+++ b/catalogs/mn5-phase2/catalog/IFS-NEMO/a1bc.yaml
@@ -119,4 +119,5 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False
 

--- a/catalogs/mn5-phase2/catalog/IFS-NEMO/a1g3.yaml
+++ b/catalogs/mn5-phase2/catalog/IFS-NEMO/a1g3.yaml
@@ -103,3 +103,4 @@ sources:
     metadata:
       # fixer_name: ifs-nemo-reduced-output-monthly-v1
       source_grid_name: lon-lat
+      fixer_name: False

--- a/catalogs/mn5-phase2/catalog/IFS-NEMO/a1hx.yaml
+++ b/catalogs/mn5-phase2/catalog/IFS-NEMO/a1hx.yaml
@@ -128,4 +128,5 @@ sources:
     metadata:
       # fixer_name: ifs-nemo-reduced-output-monthly-v1
       source_grid_name: lon-lat
+      fixer_name: False
 

--- a/catalogs/mn5-phase2/catalog/IFS-NEMO/a1ml.yaml
+++ b/catalogs/mn5-phase2/catalog/IFS-NEMO/a1ml.yaml
@@ -119,3 +119,4 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False

--- a/catalogs/mn5-phase2/catalog/IFS-NEMO/a1nk.yaml
+++ b/catalogs/mn5-phase2/catalog/IFS-NEMO/a1nk.yaml
@@ -119,3 +119,4 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False

--- a/catalogs/mn5-phase2/catalog/IFS-NEMO/a1oc.yaml
+++ b/catalogs/mn5-phase2/catalog/IFS-NEMO/a1oc.yaml
@@ -119,3 +119,4 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False

--- a/catalogs/mn5-phase2/catalog/IFS-NEMO/a1pr.yaml
+++ b/catalogs/mn5-phase2/catalog/IFS-NEMO/a1pr.yaml
@@ -128,5 +128,6 @@ sources:
     metadata:
       # fixer_name: ifs-nemo-reduced-output-monthly-v1
       source_grid_name: lon-lat
+      fixer_name: False
 
 

--- a/catalogs/nextgems4/catalog/ICON/ngc4008.yaml
+++ b/catalogs/nextgems4/catalog/ICON/ngc4008.yaml
@@ -90,6 +90,7 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False
   lra-r100-monthly-zarr:
     driver: zarr
     description: LRA data monthly at r100 reference on zarr
@@ -101,4 +102,4 @@ sources:
       - reference::{{ LRA_NEXTGEMS }}/ICON/ngc4008/r100/monthly/zarr/lra-monthly-files.json
     metadata:
       source_grid_name: lon-lat
-    fixer_name: false
+      fixer_name: false

--- a/catalogs/nextgems4/catalog/IFS-FESOM/ssp370.yaml
+++ b/catalogs/nextgems4/catalog/IFS-FESOM/ssp370.yaml
@@ -1081,3 +1081,4 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: False


### PR DESCRIPTION
## PR description:

Since we have a new convention that is applied when no fixer_name is found I added fixer_name: False to the LRA sources that needs to stay with the current diagnostics variable schema (in the future this can and has to be dropped).

Merging directly
