### PR TITLE
fix units for tcc ICON phase1 runs

### DIFF
--- a/catalogs/climatedt-phase1/catalog/ICON/historical-1990.yaml
+++ b/catalogs/climatedt-phase1/catalog/ICON/historical-1990.yaml
@@ -151,3 +151,4 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: icon-destine-v1-lra

--- a/catalogs/climatedt-phase1/catalog/ICON/ssp370.yaml
+++ b/catalogs/climatedt-phase1/catalog/ICON/ssp370.yaml
@@ -150,3 +150,4 @@ sources:
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+      fixer_name: icon-destine-v1-lra


### PR DESCRIPTION
## PR description:

Use the fix for ICON LRA run, which had wrong tcc units.
