### PR TITLE
WOCE-ARGO dataset implemented

### DIFF
--- a/.github/workflows/add-catalogs.yaml
+++ b/.github/workflows/add-catalogs.yaml
@@ -21,7 +21,7 @@ jobs:
         runs-on: ubuntu-latest
         continue-on-error: false
         container:
-            image: ghcr.io/destine-climate-dt/aqua:0.13.1
+            image: ghcr.io/destine-climate-dt/aqua:0.14.0
             options: --user root
         steps:
             - name: Checkout repository

--- a/catalogs/obs/catalog.yaml
+++ b/catalogs/obs/catalog.yaml
@@ -65,3 +65,8 @@ sources:
     driver: yaml_file_cat
     args:
       path: "{{CATALOG_DIR}}/catalog/WOA18/main.yaml"
+  WAGHC:
+    description: WAGHC climatology
+    driver: yaml_file_cat
+    args:
+      path: "{{CATALOG_DIR}}/catalog/WAGHC/main.yaml"

--- a/catalogs/obs/catalog/WAGHC/main.yaml
+++ b/catalogs/obs/catalog/WAGHC/main.yaml
@@ -1,6 +1,6 @@
 sources:
  waghc:
-    description: WOCE/Argo Global Hydrographic Climatology - WAGHC
+    description: WOCE/Argo Global Hydrographic Climatology (WAGHC) 1986-2016
     driver: yaml_file_cat
     args:
       path: "{{CATALOG_DIR}}/waghc.yaml"

--- a/catalogs/obs/catalog/WAGHC/main.yaml
+++ b/catalogs/obs/catalog/WAGHC/main.yaml
@@ -1,0 +1,6 @@
+sources:
+ waghc:
+    description: WOCE/Argo Global Hydrographic Climatology - WAGHC
+    driver: yaml_file_cat
+    args:
+      path: "{{CATALOG_DIR}}/waghc.yaml"

--- a/catalogs/obs/catalog/WAGHC/waghc.yaml
+++ b/catalogs/obs/catalog/WAGHC/waghc.yaml
@@ -1,0 +1,38 @@
+plugins:
+  source:
+    - module: intake_xarray
+
+sources:
+  clim-bar:
+    description: WAGHC 1985-2016 from isobaric interpolation
+    driver: netcdf
+    metadata:
+      source_grid_name: waghc
+      fixer_name: WAGHC
+    args:
+      urlpath:
+      - '{{DATA_PATH}}/WAGHC/WAGHC*BAR*01*.nc' 
+      xarray_kwargs:
+        decode_times: False
+  clim-pyc:
+    description: WAGHC 1985-2016 from isopyncal interpolation
+    driver: netcdf
+    metadata:
+      source_grid_name: waghc
+      fixer_name: WAGHC
+    args:
+      urlpath:
+      - '{{DATA_PATH}}/WAGHC/WAGHC*PYC*01*.nc' 
+      xarray_kwargs:
+        decode_times: False
+  clim-mixedlayer:
+    description: WAGHC 1985-2016 mixed layer depth
+    driver: netcdf
+    metadata:
+      source_grid_name: lon-lat #enough since it is 2d field
+      fixer_name: WAGHC
+    args:
+      urlpath:
+      - '{{DATA_PATH}}/WAGHC/WAGHC_Mixedlayer_Bottomdepth_UHAM-ICDC_v1_0.nc' 
+      xarray_kwargs:
+        decode_times: False


### PR DESCRIPTION
## PR description:

As per title, this integrates WOCE-ARGO https://os.copernicus.org/articles/14/1127/2018/ downloaded from MPI https://www.cen.uni-hamburg.de/en/icdc/data/ocean/waghc.html. This is a high resolution climatology for dataset, has been used for NEMO validation.

## Issues closed by this pull request:

Close 

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready" label.

 - [x] General README is updated if a new catalog is added.
 - [x] Fixes are added to AQUA if new fixes are needed.
 - [x] Grids are added to AQUA if new grids are needed.
 - [x] Tests are passing.
