### PR TITLE
Update areas and weights paths for o25.1 and e25.1

### DIFF
--- a/catalogs/climatedt-e25.1/machine.yaml
+++ b/catalogs/climatedt-e25.1/machine.yaml
@@ -11,20 +11,20 @@ MN5:
 lumi-e25.1:
   paths:
     grids: /pfs/lustrep3/appl/local/climatedt/input_data/applications/AQUA_O-25.1_v1.0/grids
-    weights: /pfs/lustrep3/appl/local/climatedt/input_data/applications/AQUA_O-25.1_v1.0/weights
-    areas: /pfs/lustrep3/appl/local/climatedt/input_data/applications/AQUA_O-25.1_v1.0/areas
+    weights: /scratch/project_465001542/aqua_cache/weights
+    areas: /scratch/project_465001542/aqua_cache/areas
 MN5-e25.1:
   paths:
     grids: /gpfs/scratch/ehpc01/input_data/applications/AQUA_O-25.1_v1.0/grids
-    weights: /gpfs/scratch/ehpc01/input_data/applications/AQUA_O-25.1_v1.0/weights
-    areas: /gpfs/scratch/ehpc01/input_data/applications/AQUA_O-25.1_v1.0/areas
+    weights: /gpfs/scratch/ehpc123/aqua_cache/weights
+    areas: /gpfs/scratch/ehpc123/aqua_cache/areas
 lumi-o25.1:
   paths:
     grids: /pfs/lustrep3/appl/local/climatedt/input_data/applications/AQUA_O-25.1_v1.0/grids
-    weights: /pfs/lustrep3/appl/local/climatedt/input_data/applications/AQUA_O-25.1_v1.0/weights
-    areas: /pfs/lustrep3/appl/local/climatedt/input_data/applications/AQUA_O-25.1_v1.0/areas
+    weights: /scratch/project_465001542/aqua_cache/weights
+    areas: /scratch/project_465001542/aqua_cache/areas
 MN5-o25.1:
   paths:
     grids: /gpfs/scratch/ehpc01/input_data/applications/AQUA_O-25.1_v1.0/grids
-    weights: /gpfs/scratch/ehpc01/input_data/applications/AQUA_O-25.1_v1.0/weights
-    areas: /gpfs/scratch/ehpc01/input_data/applications/AQUA_O-25.1_v1.0/areas
+    weights: /gpfs/scratch/ehpc123/aqua_cache/weights
+    areas: /gpfs/scratch/ehpc123/aqua_cache/areas

--- a/catalogs/climatedt-o25.1/machine.yaml
+++ b/catalogs/climatedt-o25.1/machine.yaml
@@ -11,20 +11,20 @@ MN5:
 lumi-e25.1:
   paths:
     grids: /pfs/lustrep3/appl/local/climatedt/input_data/applications/AQUA_O-25.1_v1.0/grids
-    weights: /pfs/lustrep3/appl/local/climatedt/input_data/applications/AQUA_O-25.1_v1.0/weights
-    areas: /pfs/lustrep3/appl/local/climatedt/input_data/applications/AQUA_O-25.1_v1.0/areas
+    weights: /scratch/project_465001542/aqua_cache/weights
+    areas: /scratch/project_465001542/aqua_cache/areas
 MN5-e25.1:
   paths:
     grids: /gpfs/scratch/ehpc01/input_data/applications/AQUA_O-25.1_v1.0/grids
-    weights: /gpfs/scratch/ehpc01/input_data/applications/AQUA_O-25.1_v1.0/weights
-    areas: /gpfs/scratch/ehpc01/input_data/applications/AQUA_O-25.1_v1.0/areas
+    weights: /gpfs/scratch/ehpc123/aqua_cache/weights
+    areas: /gpfs/scratch/ehpc123/aqua_cache/areas
 lumi-o25.1:
   paths:
     grids: /pfs/lustrep3/appl/local/climatedt/input_data/applications/AQUA_O-25.1_v1.0/grids
-    weights: /pfs/lustrep3/appl/local/climatedt/input_data/applications/AQUA_O-25.1_v1.0/weights
-    areas: /pfs/lustrep3/appl/local/climatedt/input_data/applications/AQUA_O-25.1_v1.0/areas
+    weights: /scratch/project_465001542/aqua_cache/weights
+    areas: /scratch/project_465001542/aqua_cache/areas
 MN5-o25.1:
   paths:
     grids: /gpfs/scratch/ehpc01/input_data/applications/AQUA_O-25.1_v1.0/grids
-    weights: /gpfs/scratch/ehpc01/input_data/applications/AQUA_O-25.1_v1.0/weights
-    areas: /gpfs/scratch/ehpc01/input_data/applications/AQUA_O-25.1_v1.0/areas
+    weights: /gpfs/scratch/ehpc123/aqua_cache/weights
+    areas: /gpfs/scratch/ehpc123/aqua_cache/areas

--- a/catalogs/obs/machine.yaml
+++ b/catalogs/obs/machine.yaml
@@ -29,29 +29,29 @@ MN5:
 lumi-e25.1:
   paths:
     grids: /pfs/lustrep3/appl/local/climatedt/input_data/applications/AQUA_O-25.1_v1.0/grids
-    weights: /pfs/lustrep3/appl/local/climatedt/input_data/applications/AQUA_O-25.1_v1.0/weights
-    areas: /pfs/lustrep3/appl/local/climatedt/input_data/applications/AQUA_O-25.1_v1.0/areas
+    weights: /scratch/project_465001542/aqua_cache/weights
+    areas: /scratch/project_465001542/aqua_cache/areas
   intake:
     DATA_PATH: /pfs/lustrep3/appl/local/climatedt/input_data/applications/AQUA-obs_v1.0/datasets
 MN5-e25.1:
   paths:
     grids: /gpfs/scratch/ehpc01/input_data/applications/AQUA_O-25.1_v1.0/grids
-    weights: /gpfs/scratch/ehpc01/input_data/applications/AQUA_O-25.1_v1.0/weights
-    areas: /gpfs/scratch/ehpc01/input_data/applications/AQUA_O-25.1_v1.0/areas
+    weights: /gpfs/scratch/ehpc123/aqua_cache/weights
+    areas: /gpfs/scratch/ehpc123/aqua_cache/areas
   intake:
     DATA_PATH: /gpfs/scratch/ehpc01/input_data/applications/AQUA-obs_v1.0/datasets
 lumi-o25.1:
   paths:
     grids: /pfs/lustrep3/appl/local/climatedt/input_data/applications/AQUA_O-25.1_v1.0/grids
-    weights: /pfs/lustrep3/appl/local/climatedt/input_data/applications/AQUA_O-25.1_v1.0/weights
-    areas: /pfs/lustrep3/appl/local/climatedt/input_data/applications/AQUA_O-25.1_v1.0/areas
+    weights: /scratch/project_465001542/aqua_cache/weights
+    areas: /scratch/project_465001542/aqua_cache/areas
   intake:
     DATA_PATH: /pfs/lustrep3/appl/local/climatedt/input_data/applications/AQUA-obs_v1.0/datasets
 MN5-o25.1:
   paths:
     grids: /gpfs/scratch/ehpc01/input_data/applications/AQUA_O-25.1_v1.0/grids
-    weights: /gpfs/scratch/ehpc01/input_data/applications/AQUA_O-25.1_v1.0/weights
-    areas: /gpfs/scratch/ehpc01/input_data/applications/AQUA_O-25.1_v1.0/areas
+    weights: /gpfs/scratch/ehpc123/aqua_cache/weights
+    areas: /gpfs/scratch/ehpc123/aqua_cache/areas
   intake:
     DATA_PATH: /gpfs/scratch/ehpc01/input_data/applications/AQUA-obs_v1.0/datasets
 hpc2020:


### PR DESCRIPTION
## PR description:

Issue reported here: 
https://jira.eduuni.fi/browse/CSCDESTINCLIMADT-625

Paths for weights and areas folders on lumi and MN5 have been updated in the `machine.yaml` files of:
`climatedt-e25.1`
`climatedt-o25.1`
`obs`
catalogs

@mnurisso @TracyMcBean @JuhaTonttila @ainagaya 

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready" label.

 - [ ] General README is updated if a new catalog is added.
 - [ ] Specific catalog README file is updated or added if needed (note of caution, errata, work to be done, etc.).
 - [ ] Tests are passing.
