### PR TITLE
ICON spp370 all on bridge now

### DIFF
--- a/catalogs/climatedt-phase1/catalog/ICON/ssp370.yaml
+++ b/catalogs/climatedt-phase1/catalog/ICON/ssp370.yaml
@@ -21,7 +21,7 @@ sources:
       data_start_date: 20200101T0000
       data_end_date: 20391231T2300
       bridge_start_date: 20200901T0000
-      bridge_end_date: 20330930T2300
+      bridge_end_date: 20391231T2300
       chunks: D  # Default time chunk size
       savefreq: h  # at what frequency are data saved
       timestep: h  # base timestep for step timestyle


### PR DESCRIPTION
## PR description:

Climatedt-phase1 ICON ssp370 data are now entirely on the bridge and after year 2033 access from HPC does not work anymore. With this change all data can be read.

