### PR TITLE
fix: correct plugin indentation and remove unused LRA data source

### DIFF
--- a/catalogs/ci/catalog/ECE4-FAST/test.yaml
+++ b/catalogs/ci/catalog/ECE4-FAST/test.yaml
@@ -1,4 +1,4 @@
-lugins:
+plugins:
   source:
     - module: intake_xarray
 
@@ -44,17 +44,3 @@ sources:
         time_counter: 1
       xarray_kwargs:
         decode_times: True
-        #use_cftime: True
-
-  # this is here only because of the OutputSaver bug #1685
-  lra-r100-monthly:
-    driver: netcdf
-    description: LRA data monthly at r100
-    args:
-      urlpath: '/dummy/*_r100_monthly_*.nc'
-      chunks: {}
-      xarray_kwargs:
-        decode_times: true
-        combine: by_coords
-    metadata:
-      source_grid_name: lon-lat


### PR DESCRIPTION
## PR description:

removed lra-r100-monthly in ECE-FAST test catalog to fix aqua tests

 - [x] Tests are passing.
