### PR TITLE
Remove step from old `climate-dt` ci sources

### DIFF
--- a/catalogs/ci/catalog/IFS/test-fdb.yaml
+++ b/catalogs/ci/catalog/IFS/test-fdb.yaml
@@ -68,7 +68,7 @@ sources:
         time: "0000"
         param: 164
         levtype: sfc
-        step: 0
+        #step: 0
       data_start_date: auto
       data_end_date: auto
       chunks: h
@@ -99,7 +99,7 @@ sources:
         time: "0000"
         param: 164
         levtype: sfc
-        step: 0
+        #step: 0
       data_start_date: 19900101T0000
       data_end_date: 19900102T0000
       bridge_start_date: 19900101T1200


### PR DESCRIPTION
## PR description:

As per title, this seems to be required to run CI/CD with new FDB 5.17.3

