### PR TITLE
EN4 wrong lev units fix

### DIFF
--- a/catalogs/obs/catalog/EN4/scripts/EN4_management.sh
+++ b/catalogs/obs/catalog/EN4/scripts/EN4_management.sh
@@ -94,9 +94,16 @@ process_variable() {
     ncatted -O -a long_name,$final_name,m,c,"$long_name" "$temp_file" 2>/dev/null || true
     ncatted -O -a standard_name,$final_name,m,c,"$standard_name" "$temp_file" 2>/dev/null || true
     
-    # 5. Rename depth dimension to lev
+    # 5a. Rename depth dimension to lev
     ncrename -d depth,lev -v depth,lev "$temp_file" 2>/dev/null || true
     ncatted -O -a standard_name,lev,c,c,"depth" "$temp_file" 2>/dev/null || true
+
+    # 5b. Standardise lev units to 'm'
+    info "Standardizing lev coordinate units to 'm'..." >&2
+    ncatted -O -a units,lev,o,c,"m" "$temp_file" 2>/dev/null || true
+
+    # 5c. Optional: Add positive attribute for clarity
+    ncatted -O -a positive,lev,o,c,"down" "$temp_file" 2>/dev/null || true
     
     # 6. Convert time to float
     local final_temp="temp_final_${final_name}_${year}${month_str}.nc"
@@ -351,7 +358,7 @@ done
 
 
 
-info "=== TEMPORARY: Coordinate comparison ==="
+info "=== OPTIONAL: Coordinate comparison ==="
 
 # Function to compare coordinates between reference and new data
 compare_coordinates() {


### PR DESCRIPTION
## PR description:

Fix discussed in #195 about height unit for `lev`.

In addition, I also inserted a `positive="down"` attribute that Copilot suggests as best practice for oceanic vertical coordinates. If you're ok, we can keep it. 

## Issues closed by this pull request:

Close #195 

----