### PR TITLE
(untested) point to aqua-dvc

### DIFF
--- a/catalogs/mn5-phase2/machine.yaml
+++ b/catalogs/mn5-phase2/machine.yaml
@@ -1,8 +1,8 @@
 MN5:
   paths:
-    grids: /gpfs/scratch/ehpc01/data/AQUA/grids
-    weights: /gpfs/scratch/ehpc01/data/AQUA/weights
-    areas: /gpfs/scratch/ehpc01/data/AQUA/areas
+    grids: /gpfs/projects/ehpc01/data/AQUA/aqua-dvc/grids
+    weights: /gpfs/projects/ehpc01/data/AQUA/aqua-dvc/weights
+    areas: /gpfs/projects/ehpc01/data/AQUA/aqua-dvc/areas
   intake:
     ECCODES_PATH: /gpfs/projects/ehpc01/eccodes
     FDB_HOME: /gpfs/scratch/ehpc01/experiments/


### PR DESCRIPTION
## PR description:

Updates the machine file for the mn5-phase2 catalog pointing to the aqua-dvc directory. Related discussion: https://gitlab.earth.bsc.es/digital-twins/de_340-2/workflow/-/merge_requests/1030#note_403093

@mnurisso @ghosh97 @oloapinivad @tovaz92 

## Issues closed by this pull request:

Close 

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready" label.

 - [ ] General README is updated if a new catalog is added.
 - [ ] Fixes are added to AQUA if new fixes are needed.
 - [ ] Grids are added to AQUA if new grids are needed.
 - [ ] Specific catalog README file is updated or added if needed (note of caution, errata, work to be done, etc.).
 - [ ] Tests are passing.
