### PR TITLE
Change grid to lon-lat-r100 for climatedt-phase1/IFS-NEMO/ssp370

### DIFF
--- a/catalogs/climatedt-phase1/catalog/IFS-FESOM/ssp370.yaml
+++ b/catalogs/climatedt-phase1/catalog/IFS-FESOM/ssp370.yaml
@@ -471,4 +471,4 @@ sources:
         decode_times: true
         combine: by_coords
     metadata:
-      source_grid_name: lon-lat
+      source_grid_name: lon-lat-r100


### PR DESCRIPTION
This connects to https://github.com/DestinE-Climate-DT/AQUA/issues/2405 which adds a new `lon-lat-r100` `source_grid_name` providing an explicit grid file (avoiding a useless `_retriev_plain()`. 

In general  as a policy we do not change old sources but this one is an exception because we use idaily t for testing the aqua analysis stack.
