### PR TITLE
Baseline 4xCO2 IFS-NEMO

### DIFF
--- a/catalogs/mn5-phase2/catalog/IFS-NEMO/a2vh.yaml
+++ b/catalogs/mn5-phase2/catalog/IFS-NEMO/a2vh.yaml
@@ -1,0 +1,1 @@
+/gpfs/scratch/ehpc01/bsc998159//a2vh/git_project/catalog/catalogs/mn5-phase2/catalog/IFS-NEMO/a2vh.yaml

--- a/catalogs/mn5-phase2/catalog/IFS-NEMO/a2vu.yaml
+++ b/catalogs/mn5-phase2/catalog/IFS-NEMO/a2vu.yaml
@@ -1,0 +1,1 @@
+/gpfs/scratch/ehpc01/bsc998159//a2vu/git_project/catalog/catalogs/mn5-phase2/catalog/IFS-NEMO/a2vu.yaml

--- a/catalogs/mn5-phase2/catalog/IFS-NEMO/a2vu.yaml
+++ b/catalogs/mn5-phase2/catalog/IFS-NEMO/a2vu.yaml
@@ -1,1 +1,436 @@
-/gpfs/scratch/ehpc01/bsc998159//a2vu/git_project/catalog/catalogs/mn5-phase2/catalog/IFS-NEMO/a2vu.yaml
+sources:
+  hourly-hpz7-atm2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: cont  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2vu  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 151
+        levtype: sfc
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: D
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2vu , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [151, 165, 166, 167, 168, 207, 228164, 235035, 235040, 235043, 
+          235055]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2vu/a2vu.yaml
+  daily-hpz7-atm2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: cont  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2vu  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 172
+        levtype: sfc
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: D
+      savefreq: D
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2vu , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [172, 228002]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2vu/a2vu.yaml
+  monthly-hpz7-atm2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: cont  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2vu  # To be overwritten by workflow/config file
+        type: fc
+        stream: clmn
+        year: null
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 228004
+        levtype: sfc
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'ifs-nemo a2vu , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [228004, 235031, 235033, 235034, 235035, 235036, 235037, 235038,
+        235039, 235040, 235041, 235042, 235043, 235049, 235050, 235051, 235052, 
+          235053, 235055, 235151, 235165, 235166, 235288]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2vu/a2vu.yaml
+  6-hourly-hpz7-atm3d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: cont  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2vu  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 129
+        levtype: pl
+        levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
+            600, 700, 850, 925, 1000]
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: 6h
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2vu , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 
+          700, 850, 925, 1000]
+      variables: [129, 131, 132]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2vu/a2vu.yaml
+  monthly-hpz7-atm3d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: cont  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2vu  # To be overwritten by workflow/config file
+        type: fc
+        stream: clmn
+        year: null
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 235130
+        levtype: pl
+        levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
+            600, 700, 850, 925, 1000]
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'ifs-nemo a2vu , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 
+          700, 850, 925, 1000]
+      variables: [235130, 235131, 235132, 235133]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2vu/a2vu.yaml
+  daily-hpz7-oce2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: cont  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2vu  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 263000
+        levtype: o2d
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: D
+      savefreq: D
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2vu , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [263000, 263001, 263003, 263004, 263100, 263101, 263124]
+      source_grid_name: nemo-eORCA025-hpz7-nested-v3
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2vu/a2vu.yaml
+  monthly-hpz7-oce2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: cont  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2vu  # To be overwritten by workflow/config file
+        type: fc
+        stream: clmn
+        year: null
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 263000
+        levtype: o2d
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'ifs-nemo a2vu , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [263000, 263001, 263008, 263100, 263101, 263123]
+      source_grid_name: nemo-eORCA025-hpz7-nested-v3
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2vu/a2vu.yaml
+  monthly-hpz7-oce3d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: cont  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2vu  # To be overwritten by workflow/config file
+        type: fc
+        stream: clmn
+        year: null
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 263500
+        levtype: o3d
+        levelist: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+          19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
+          37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
+          55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72,
+          73, 74, 75]
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'ifs-nemo a2vu , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [0.5057600140571594, 1.5558552742004395, 2.6676816940307617, 
+          3.8562798500061035, 5.140361309051514, 6.543033599853516, 
+          8.09251880645752, 9.822750091552734, 11.773679733276367, 
+          13.99103832244873, 16.52532196044922, 19.42980194091797, 
+          22.75761604309082, 26.558300018310547, 30.874561309814453, 
+          35.740203857421875, 41.180023193359375, 47.21189498901367, 
+          53.85063552856445, 61.11283874511719, 69.02168273925781, 
+          77.61116027832031, 86.92942810058594, 97.04131317138672, 
+          108.03028106689453, 120.0, 133.07582092285156, 147.40625, 
+          163.16445922851562, 180.5499267578125, 199.7899627685547, 
+          221.14117431640625, 244.890625, 271.35638427734375, 300.88751220703125,
+        333.8628234863281, 370.6884765625, 411.7938537597656, 457.6256103515625, 
+          508.639892578125, 565.2922973632812, 628.0260009765625, 
+          697.2586669921875, 773.3682861328125, 856.678955078125, 
+          947.4478759765625, 1045.854248046875, 1151.9912109375, 
+          1265.8614501953125, 1387.376953125, 1516.3636474609375, 
+          1652.5684814453125, 1795.6707763671875, 1945.2955322265625, 
+          2101.026611328125, 2262.421630859375, 2429.025146484375, 
+          2600.38037109375, 2776.039306640625, 2955.5703125, 3138.56494140625, 
+          3324.640869140625, 3513.445556640625, 3704.65673828125, 
+          3897.98193359375, 4093.15869140625, 4289.95263671875, 4488.15478515625,
+        4687.5810546875, 4888.06982421875, 5089.478515625, 5291.68310546875, 
+          5494.5751953125, 5698.060546875, 5902.0576171875]
+      variables: [263500, 263501]
+      source_grid_name: nemo-eORCA025-hpz7-nested-3d-v3
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2vu/a2vu.yaml
+  hourly-hpz7-hl:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: cont  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2vu  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 131
+        levtype: hl
+        levelist: [100]
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: D
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2vu , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [100]
+      variables: [131, 132]
+      source_grid_name: hpz7
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2vu/a2vu.yaml
+  lra-r100-monthly:
+    driver: netcdf
+    description: LRA data monthly at r100
+    args:
+      urlpath: 
+        /gpfs/scratch/ehpc01/bsc998159/a2vu/output/LRA/fc0/mn5-phase2/IFS-NEMO/a2vu/r1/r100/monthly/mean/global/*a2vu_r1_r100_monthly_*.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+        combine: by_coords
+    metadata:
+      source_grid_name: lon-lat
+  aqua-radiation-timeseries:
+    driver: netcdf
+    description: AQUA diagnostic radiation data for product timeseries
+    args:
+      urlpath: 
+        /gpfs/scratch/ehpc01/bsc998159/a2vu/output/aqua-analysis/mn5-phase2/IFS-NEMO/a2vu/{{realization}}/radiation/netcdf/radiation.timeseries.mn5-phase2.IFS-NEMO.a2vu.{{realization}}.*.{{freq}}.{{region}}.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      freq:
+        description: Parameter freq
+        default: monthly
+        type: str
+        allowed:
+        - monthly
+        - annual
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+      region:
+        description: Parameter region
+        default: global
+        type: str
+        allowed:
+        - global
+  aqua-atmosphere-timeseries:
+    driver: netcdf
+    description: AQUA diagnostic atmosphere data for product timeseries
+    args:
+      urlpath: 
+        /gpfs/scratch/ehpc01/bsc998159/a2vu/output/aqua-analysis/mn5-phase2/IFS-NEMO/a2vu/{{realization}}/timeseries/netcdf/atmosphere.timeseries.mn5-phase2.IFS-NEMO.a2vu.{{realization}}.*.{{freq}}.{{region}}.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      freq:
+        description: Parameter freq
+        default: monthly
+        type: str
+        allowed:
+        - monthly
+        - annual
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+      region:
+        description: Parameter region
+        default: global
+        type: str
+        allowed:
+        - global
+        - tropics
+        - europe
+  aqua-atmosphere-seasonalcycles:
+    driver: netcdf
+    description: AQUA diagnostic atmosphere data for product seasonalcycles
+    args:
+      urlpath: 
+        /gpfs/scratch/ehpc01/bsc998159/a2vu/output/aqua-analysis/mn5-phase2/IFS-NEMO/a2vu/{{realization}}/timeseries/netcdf/atmosphere.seasonalcycles.mn5-phase2.IFS-NEMO.a2vu.{{realization}}.*.{{freq}}.{{region}}.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      freq:
+        description: Parameter freq
+        default: monthly
+        type: str
+        allowed:
+        - monthly
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+      region:
+        description: Parameter region
+        default: global
+        type: str
+        allowed:
+        - global

--- a/catalogs/mn5-phase2/catalog/IFS-NEMO/a2wb.yaml
+++ b/catalogs/mn5-phase2/catalog/IFS-NEMO/a2wb.yaml
@@ -5,12 +5,12 @@ sources:
         class: d1
         dataset: climate-dt
         activity: baseline  # To be overwritten by workflow/config file
-        experiment: cont  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
         generation: 2  # To be overwritten by workflow/config file
         model: IFS-NEMO
         realization: 1
         resolution: standard
-        expver: a2vh  # To be overwritten by workflow/config file
+        expver: a2wb  # To be overwritten by workflow/config file
         type: fc
         stream: clte
         date: null
@@ -23,27 +23,27 @@ sources:
       savefreq: h
       timestep: h
       timestyle: date
-    description: 'ifs-nemo a2vh , grids: tco399 eORCA025'
+    description: 'ifs-nemo a2wb , grids: tco399 eORCA025'
     driver: gsv
     metadata:
-      fdb_home: /gpfs/scratch/ehpc01/experiments/a2vh/fdb
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
       variables: [151, 165, 166, 167, 168, 207, 228164, 235035, 235040, 235043, 
           235055]
       source_grid_name: hpz7-nested
       fixer_name: climatedt-phase2-reduced
-      fdb_info_file: /gpfs/scratch/ehpc01/experiments/a2vh/fdb/a2vh.yaml
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wb/a2wb.yaml
   daily-hpz7-atm2d:
     args:
       request:
         class: d1
         dataset: climate-dt
         activity: baseline  # To be overwritten by workflow/config file
-        experiment: cont  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
         generation: 2  # To be overwritten by workflow/config file
         model: IFS-NEMO
         realization: 1
         resolution: standard
-        expver: a2vh  # To be overwritten by workflow/config file
+        expver: a2wb  # To be overwritten by workflow/config file
         type: fc
         stream: clte
         date: null
@@ -56,26 +56,26 @@ sources:
       savefreq: D
       timestep: h
       timestyle: date
-    description: 'ifs-nemo a2vh , grids: tco399 eORCA025'
+    description: 'ifs-nemo a2wb , grids: tco399 eORCA025'
     driver: gsv
     metadata:
-      fdb_home: /gpfs/scratch/ehpc01/experiments/a2vh/fdb
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
       variables: [172, 228002]
       source_grid_name: hpz7-nested
       fixer_name: climatedt-phase2-reduced
-      fdb_info_file: /gpfs/scratch/ehpc01/experiments/a2vh/fdb/a2vh.yaml
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wb/a2wb.yaml
   monthly-hpz7-atm2d:
     args:
       request:
         class: d1
         dataset: climate-dt
         activity: baseline  # To be overwritten by workflow/config file
-        experiment: cont  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
         generation: 2  # To be overwritten by workflow/config file
         model: IFS-NEMO
         realization: 1
         resolution: standard
-        expver: a2vh  # To be overwritten by workflow/config file
+        expver: a2wb  # To be overwritten by workflow/config file
         type: fc
         stream: clmn
         year: null
@@ -88,28 +88,28 @@ sources:
       savefreq: MS
       timestep: h
       timestyle: yearmonth
-    description: 'ifs-nemo a2vh , grids: tco399 eORCA025'
+    description: 'ifs-nemo a2wb , grids: tco399 eORCA025'
     driver: gsv
     metadata:
-      fdb_home: /gpfs/scratch/ehpc01/experiments/a2vh/fdb
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
       variables: [228004, 235031, 235033, 235034, 235035, 235036, 235037, 235038,
         235039, 235040, 235041, 235042, 235043, 235049, 235050, 235051, 235052, 
           235053, 235055, 235151, 235165, 235166, 235288]
       source_grid_name: hpz7-nested
       fixer_name: climatedt-phase2-reduced
-      fdb_info_file: /gpfs/scratch/ehpc01/experiments/a2vh/fdb/a2vh.yaml
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wb/a2wb.yaml
   6-hourly-hpz7-atm3d:
     args:
       request:
         class: d1
         dataset: climate-dt
         activity: baseline  # To be overwritten by workflow/config file
-        experiment: cont  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
         generation: 2  # To be overwritten by workflow/config file
         model: IFS-NEMO
         realization: 1
         resolution: standard
-        expver: a2vh  # To be overwritten by workflow/config file
+        expver: a2wb  # To be overwritten by workflow/config file
         type: fc
         stream: clte
         date: null
@@ -124,28 +124,28 @@ sources:
       savefreq: h
       timestep: h
       timestyle: date
-    description: 'ifs-nemo a2vh , grids: tco399 eORCA025'
+    description: 'ifs-nemo a2wb , grids: tco399 eORCA025'
     driver: gsv
     metadata:
-      fdb_home: /gpfs/scratch/ehpc01/experiments/a2vh/fdb
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
       levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 
           700, 850, 925, 1000]
       variables: [129, 131, 132]
       source_grid_name: hpz7-nested
       fixer_name: climatedt-phase2-reduced
-      fdb_info_file: /gpfs/scratch/ehpc01/experiments/a2vh/fdb/a2vh.yaml
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wb/a2wb.yaml
   monthly-hpz7-atm3d:
     args:
       request:
         class: d1
         dataset: climate-dt
         activity: baseline  # To be overwritten by workflow/config file
-        experiment: cont  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
         generation: 2  # To be overwritten by workflow/config file
         model: IFS-NEMO
         realization: 1
         resolution: standard
-        expver: a2vh  # To be overwritten by workflow/config file
+        expver: a2wb  # To be overwritten by workflow/config file
         type: fc
         stream: clmn
         year: null
@@ -160,28 +160,28 @@ sources:
       savefreq: MS
       timestep: h
       timestyle: yearmonth
-    description: 'ifs-nemo a2vh , grids: tco399 eORCA025'
+    description: 'ifs-nemo a2wb , grids: tco399 eORCA025'
     driver: gsv
     metadata:
-      fdb_home: /gpfs/scratch/ehpc01/experiments/a2vh/fdb
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
       levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 
           700, 850, 925, 1000]
       variables: [235130, 235131, 235132, 235133]
       source_grid_name: hpz7-nested
       fixer_name: climatedt-phase2-reduced
-      fdb_info_file: /gpfs/scratch/ehpc01/experiments/a2vh/fdb/a2vh.yaml
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wb/a2wb.yaml
   daily-hpz7-oce2d:
     args:
       request:
         class: d1
         dataset: climate-dt
         activity: baseline  # To be overwritten by workflow/config file
-        experiment: cont  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
         generation: 2  # To be overwritten by workflow/config file
         model: IFS-NEMO
         realization: 1
         resolution: standard
-        expver: a2vh  # To be overwritten by workflow/config file
+        expver: a2wb  # To be overwritten by workflow/config file
         type: fc
         stream: clte
         date: null
@@ -194,26 +194,26 @@ sources:
       savefreq: D
       timestep: h
       timestyle: date
-    description: 'ifs-nemo a2vh , grids: tco399 eORCA025'
+    description: 'ifs-nemo a2wb , grids: tco399 eORCA025'
     driver: gsv
     metadata:
-      fdb_home: /gpfs/scratch/ehpc01/experiments/a2vh/fdb
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
       variables: [263000, 263001, 263003, 263004, 263100, 263101, 263124]
       source_grid_name: nemo-eORCA025-hpz7-nested-v3
       fixer_name: climatedt-phase2-reduced
-      fdb_info_file: /gpfs/scratch/ehpc01/experiments/a2vh/fdb/a2vh.yaml
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wb/a2wb.yaml
   monthly-hpz7-oce2d:
     args:
       request:
         class: d1
         dataset: climate-dt
         activity: baseline  # To be overwritten by workflow/config file
-        experiment: cont  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
         generation: 2  # To be overwritten by workflow/config file
         model: IFS-NEMO
         realization: 1
         resolution: standard
-        expver: a2vh  # To be overwritten by workflow/config file
+        expver: a2wb  # To be overwritten by workflow/config file
         type: fc
         stream: clmn
         year: null
@@ -226,26 +226,26 @@ sources:
       savefreq: MS
       timestep: h
       timestyle: yearmonth
-    description: 'ifs-nemo a2vh , grids: tco399 eORCA025'
+    description: 'ifs-nemo a2wb , grids: tco399 eORCA025'
     driver: gsv
     metadata:
-      fdb_home: /gpfs/scratch/ehpc01/experiments/a2vh/fdb
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
       variables: [263000, 263001, 263008, 263100, 263101, 263123]
       source_grid_name: nemo-eORCA025-hpz7-nested-v3
       fixer_name: climatedt-phase2-reduced
-      fdb_info_file: /gpfs/scratch/ehpc01/experiments/a2vh/fdb/a2vh.yaml
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wb/a2wb.yaml
   monthly-hpz7-oce3d:
     args:
       request:
         class: d1
         dataset: climate-dt
         activity: baseline  # To be overwritten by workflow/config file
-        experiment: cont  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
         generation: 2  # To be overwritten by workflow/config file
         model: IFS-NEMO
         realization: 1
         resolution: standard
-        expver: a2vh  # To be overwritten by workflow/config file
+        expver: a2wb  # To be overwritten by workflow/config file
         type: fc
         stream: clmn
         year: null
@@ -263,10 +263,10 @@ sources:
       savefreq: MS
       timestep: h
       timestyle: yearmonth
-    description: 'ifs-nemo a2vh , grids: tco399 eORCA025'
+    description: 'ifs-nemo a2wb , grids: tco399 eORCA025'
     driver: gsv
     metadata:
-      fdb_home: /gpfs/scratch/ehpc01/experiments/a2vh/fdb
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
       levels: [0.5057600140571594, 1.5558552742004395, 2.6676816940307617, 
           3.8562798500061035, 5.140361309051514, 6.543033599853516, 
           8.09251880645752, 9.822750091552734, 11.773679733276367, 
@@ -293,19 +293,19 @@ sources:
       variables: [263500, 263501]
       source_grid_name: nemo-eORCA025-hpz7-nested-3d-v3
       fixer_name: climatedt-phase2-reduced
-      fdb_info_file: /gpfs/scratch/ehpc01/experiments/a2vh/fdb/a2vh.yaml
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wb/a2wb.yaml
   hourly-hpz7-hl:
     args:
       request:
         class: d1
         dataset: climate-dt
         activity: baseline  # To be overwritten by workflow/config file
-        experiment: cont  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
         generation: 2  # To be overwritten by workflow/config file
         model: IFS-NEMO
         realization: 1
         resolution: standard
-        expver: a2vh  # To be overwritten by workflow/config file
+        expver: a2wb  # To be overwritten by workflow/config file
         type: fc
         stream: clte
         date: null
@@ -319,24 +319,118 @@ sources:
       savefreq: h
       timestep: h
       timestyle: date
-    description: 'ifs-nemo a2vh , grids: tco399 eORCA025'
+    description: 'ifs-nemo a2wb , grids: tco399 eORCA025'
     driver: gsv
     metadata:
-      fdb_home: /gpfs/scratch/ehpc01/experiments/a2vh/fdb
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
       levels: [100]
       variables: [131, 132]
       source_grid_name: hpz7
       fixer_name: climatedt-phase2-reduced
-      fdb_info_file: /gpfs/scratch/ehpc01/experiments/a2vh/fdb/a2vh.yaml
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wb/a2wb.yaml
   lra-r100-monthly:
     driver: netcdf
     description: LRA data monthly at r100
     args:
-      urlpath:
-        /gpfs/scratch/ehpc01/bsc998159/a2vh/output/LRA/fc0/mn5-phase2/IFS-NEMO/a2vh/r1/r100/monthly/mean/global/*a2vh_r1_r100_monthly_*.nc
+      urlpath: 
+        /gpfs/scratch/ehpc01/bsc998159/a2wb/output/LRA/fc0/mn5-phase2/IFS-NEMO/a2wb/r1/r100/monthly/mean/global/*a2wb_r1_r100_monthly_*.nc
       chunks: {}
       xarray_kwargs:
         decode_times: true
         combine: by_coords
     metadata:
       source_grid_name: lon-lat
+  aqua-radiation-timeseries:
+    driver: netcdf
+    description: AQUA diagnostic radiation data for product timeseries
+    args:
+      urlpath: 
+        /gpfs/scratch/ehpc01/bsc998159/a2wb/output/aqua-analysis/mn5-phase2/IFS-NEMO/a2wb/{{realization}}/radiation/netcdf/radiation.timeseries.mn5-phase2.IFS-NEMO.a2wb.{{realization}}.*.{{freq}}.{{region}}.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      freq:
+        description: Parameter freq
+        default: monthly
+        type: str
+        allowed:
+        - monthly
+        - annual
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+      region:
+        description: Parameter region
+        default: global
+        type: str
+        allowed:
+        - global
+  aqua-atmosphere-seasonalcycles:
+    driver: netcdf
+    description: AQUA diagnostic atmosphere data for product seasonalcycles
+    args:
+      urlpath: 
+        /gpfs/scratch/ehpc01/bsc998159/a2wb/output/aqua-analysis/mn5-phase2/IFS-NEMO/a2wb/{{realization}}/timeseries/netcdf/atmosphere.seasonalcycles.mn5-phase2.IFS-NEMO.a2wb.{{realization}}.*.{{freq}}.{{region}}.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      freq:
+        description: Parameter freq
+        default: monthly
+        type: str
+        allowed:
+        - monthly
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+      region:
+        description: Parameter region
+        default: global
+        type: str
+        allowed:
+        - global
+  aqua-atmosphere-timeseries:
+    driver: netcdf
+    description: AQUA diagnostic atmosphere data for product timeseries
+    args:
+      urlpath: 
+        /gpfs/scratch/ehpc01/bsc998159/a2wb/output/aqua-analysis/mn5-phase2/IFS-NEMO/a2wb/{{realization}}/timeseries/netcdf/atmosphere.timeseries.mn5-phase2.IFS-NEMO.a2wb.{{realization}}.*.{{freq}}.{{region}}.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      freq:
+        description: Parameter freq
+        default: monthly
+        type: str
+        allowed:
+        - monthly
+        - annual
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+      region:
+        description: Parameter region
+        default: global
+        type: str
+        allowed:
+        - global
+        - tropics
+        - europe

--- a/catalogs/mn5-phase2/catalog/IFS-NEMO/a2wd.yaml
+++ b/catalogs/mn5-phase2/catalog/IFS-NEMO/a2wd.yaml
@@ -1,0 +1,824 @@
+sources:
+  hourly-hpz10-atm2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: high
+        expver: a2wd  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 151
+        levtype: sfc
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: D
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2wd , grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [151, 165, 166, 167, 168, 207, 228164, 235035, 235040, 235043, 
+          235055]
+      source_grid_name: hpz10-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wd/a2wd.yaml
+  hourly-hpz7-atm2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2wd  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 151
+        levtype: sfc
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: D
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2wd , grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [151, 165, 166, 167, 168, 207, 228164, 235035, 235040, 235043, 
+          235055]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wd/a2wd.yaml
+  daily-hpz10-atm2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: high
+        expver: a2wd  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 172
+        levtype: sfc
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: D
+      savefreq: D
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2wd , grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [172, 228002]
+      source_grid_name: hpz10-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wd/a2wd.yaml
+  daily-hpz7-atm2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2wd  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 172
+        levtype: sfc
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: D
+      savefreq: D
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2wd , grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [172, 228002]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wd/a2wd.yaml
+  monthly-hpz10-atm2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: high
+        expver: a2wd  # To be overwritten by workflow/config file
+        type: fc
+        stream: clmn
+        year: null
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 228004
+        levtype: sfc
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'ifs-nemo a2wd , grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [228004, 235031, 235033, 235034, 235035, 235036, 235037, 235038,
+        235039, 235040, 235041, 235042, 235043, 235049, 235050, 235051, 235052, 
+          235053, 235055, 235151, 235165, 235166, 235288]
+      source_grid_name: hpz10-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wd/a2wd.yaml
+  monthly-hpz7-atm2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2wd  # To be overwritten by workflow/config file
+        type: fc
+        stream: clmn
+        year: null
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 228004
+        levtype: sfc
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'ifs-nemo a2wd , grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [228004, 235031, 235033, 235034, 235035, 235036, 235037, 235038,
+        235039, 235040, 235041, 235042, 235043, 235049, 235050, 235051, 235052, 
+          235053, 235055, 235151, 235165, 235166, 235288]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wd/a2wd.yaml
+  6-hourly-hpz10-atm3d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: high
+        expver: a2wd  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 129
+        levtype: pl
+        levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
+            600, 700, 850, 925, 1000]
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: 6h
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2wd , grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 
+          700, 850, 925, 1000]
+      variables: [129, 131, 132]
+      source_grid_name: hpz10-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wd/a2wd.yaml
+  6-hourly-hpz7-atm3d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2wd  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 129
+        levtype: pl
+        levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
+            600, 700, 850, 925, 1000]
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: 6h
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2wd , grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 
+          700, 850, 925, 1000]
+      variables: [129, 131, 132]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wd/a2wd.yaml
+  monthly-hpz10-atm3d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: high
+        expver: a2wd  # To be overwritten by workflow/config file
+        type: fc
+        stream: clmn
+        year: null
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 235130
+        levtype: pl
+        levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
+            600, 700, 850, 925, 1000]
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'ifs-nemo a2wd , grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 
+          700, 850, 925, 1000]
+      variables: [235130, 235131, 235132, 235133]
+      source_grid_name: hpz10-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wd/a2wd.yaml
+  monthly-hpz7-atm3d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2wd  # To be overwritten by workflow/config file
+        type: fc
+        stream: clmn
+        year: null
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 235130
+        levtype: pl
+        levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
+            600, 700, 850, 925, 1000]
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'ifs-nemo a2wd , grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 
+          700, 850, 925, 1000]
+      variables: [235130, 235131, 235132, 235133]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wd/a2wd.yaml
+  daily-hpz10-oce2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: high
+        expver: a2wd  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 263000
+        levtype: o2d
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: D
+      savefreq: D
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2wd , grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [263000, 263001, 263003, 263004, 263100, 263101, 263124]
+      source_grid_name: nemo-eORCA12-hpz10-nested-v3
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wd/a2wd.yaml
+  daily-hpz7-oce2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2wd  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 263000
+        levtype: o2d
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: D
+      savefreq: D
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2wd , grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [263000, 263001, 263003, 263004, 263100, 263101, 263124]
+      source_grid_name: nemo-eORCA12-hpz7-nested-v3
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wd/a2wd.yaml
+  monthly-hpz10-oce2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: high
+        expver: a2wd  # To be overwritten by workflow/config file
+        type: fc
+        stream: clmn
+        year: null
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 263000
+        levtype: o2d
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'ifs-nemo a2wd , grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [263000, 263001, 263008, 263100, 263101, 263123]
+      source_grid_name: nemo-eORCA12-hpz10-nested-v3
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wd/a2wd.yaml
+  monthly-hpz7-oce2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2wd  # To be overwritten by workflow/config file
+        type: fc
+        stream: clmn
+        year: null
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 263000
+        levtype: o2d
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'ifs-nemo a2wd , grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [263000, 263001, 263008, 263100, 263101, 263123]
+      source_grid_name: nemo-eORCA12-hpz7-nested-v3
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wd/a2wd.yaml
+  monthly-hpz10-oce3d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: high
+        expver: a2wd  # To be overwritten by workflow/config file
+        type: fc
+        stream: clmn
+        year: null
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 263500
+        levtype: o3d
+        levelist: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+          19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
+          37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
+          55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72,
+          73, 74, 75]
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'ifs-nemo a2wd , grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [0.5057600140571594, 1.5558552742004395, 2.6676816940307617, 
+          3.8562798500061035, 5.140361309051514, 6.543033599853516, 
+          8.09251880645752, 9.822750091552734, 11.773679733276367, 
+          13.99103832244873, 16.52532196044922, 19.42980194091797, 
+          22.75761604309082, 26.558300018310547, 30.874561309814453, 
+          35.740203857421875, 41.180023193359375, 47.21189498901367, 
+          53.85063552856445, 61.11283874511719, 69.02168273925781, 
+          77.61116027832031, 86.92942810058594, 97.04131317138672, 
+          108.03028106689453, 120.0, 133.07582092285156, 147.40625, 
+          163.16445922851562, 180.5499267578125, 199.7899627685547, 
+          221.14117431640625, 244.890625, 271.35638427734375, 300.88751220703125,
+        333.8628234863281, 370.6884765625, 411.7938537597656, 457.6256103515625, 
+          508.639892578125, 565.2922973632812, 628.0260009765625, 
+          697.2586669921875, 773.3682861328125, 856.678955078125, 
+          947.4478759765625, 1045.854248046875, 1151.9912109375, 
+          1265.8614501953125, 1387.376953125, 1516.3636474609375, 
+          1652.5684814453125, 1795.6707763671875, 1945.2955322265625, 
+          2101.026611328125, 2262.421630859375, 2429.025146484375, 
+          2600.38037109375, 2776.039306640625, 2955.5703125, 3138.56494140625, 
+          3324.640869140625, 3513.445556640625, 3704.65673828125, 
+          3897.98193359375, 4093.15869140625, 4289.95263671875, 4488.15478515625,
+        4687.5810546875, 4888.06982421875, 5089.478515625, 5291.68310546875, 
+          5494.5751953125, 5698.060546875, 5902.0576171875]
+      variables: [263500, 263501]
+      source_grid_name: nemo-eORCA12-hpz10-nested-3d-v3
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wd/a2wd.yaml
+  monthly-hpz7-oce3d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2wd  # To be overwritten by workflow/config file
+        type: fc
+        stream: clmn
+        year: null
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 263500
+        levtype: o3d
+        levelist: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+          19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
+          37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
+          55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72,
+          73, 74, 75]
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'ifs-nemo a2wd , grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [0.5057600140571594, 1.5558552742004395, 2.6676816940307617, 
+          3.8562798500061035, 5.140361309051514, 6.543033599853516, 
+          8.09251880645752, 9.822750091552734, 11.773679733276367, 
+          13.99103832244873, 16.52532196044922, 19.42980194091797, 
+          22.75761604309082, 26.558300018310547, 30.874561309814453, 
+          35.740203857421875, 41.180023193359375, 47.21189498901367, 
+          53.85063552856445, 61.11283874511719, 69.02168273925781, 
+          77.61116027832031, 86.92942810058594, 97.04131317138672, 
+          108.03028106689453, 120.0, 133.07582092285156, 147.40625, 
+          163.16445922851562, 180.5499267578125, 199.7899627685547, 
+          221.14117431640625, 244.890625, 271.35638427734375, 300.88751220703125,
+        333.8628234863281, 370.6884765625, 411.7938537597656, 457.6256103515625, 
+          508.639892578125, 565.2922973632812, 628.0260009765625, 
+          697.2586669921875, 773.3682861328125, 856.678955078125, 
+          947.4478759765625, 1045.854248046875, 1151.9912109375, 
+          1265.8614501953125, 1387.376953125, 1516.3636474609375, 
+          1652.5684814453125, 1795.6707763671875, 1945.2955322265625, 
+          2101.026611328125, 2262.421630859375, 2429.025146484375, 
+          2600.38037109375, 2776.039306640625, 2955.5703125, 3138.56494140625, 
+          3324.640869140625, 3513.445556640625, 3704.65673828125, 
+          3897.98193359375, 4093.15869140625, 4289.95263671875, 4488.15478515625,
+        4687.5810546875, 4888.06982421875, 5089.478515625, 5291.68310546875, 
+          5494.5751953125, 5698.060546875, 5902.0576171875]
+      variables: [263500, 263501]
+      source_grid_name: nemo-eORCA12-hpz7-nested-3d-v3
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wd/a2wd.yaml
+  hourly-hpz10-hl:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: high
+        expver: a2wd  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 131
+        levtype: hl
+        levelist: [100]
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: D
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2wd , grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [100]
+      variables: [131, 132]
+      source_grid_name: hpz10
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wd/a2wd.yaml
+  hourly-hpz7-hl:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2wd  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 131
+        levtype: hl
+        levelist: [100]
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: D
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2wd , grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [100]
+      variables: [131, 132]
+      source_grid_name: hpz7
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2wd/a2wd.yaml
+  lra-r100-monthly:
+    driver: netcdf
+    description: LRA data monthly at r100
+    args:
+      urlpath: 
+        /gpfs/scratch/ehpc01/bsc998159/a2wd/output/LRA/fc0/mn5-phase2/IFS-NEMO/a2wd/r1/r100/monthly/mean/global/*a2wd_r1_r100_monthly_*.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+        combine: by_coords
+    metadata:
+      source_grid_name: lon-lat
+  aqua-atmosphere-timeseries:
+    driver: netcdf
+    description: AQUA diagnostic atmosphere data for product timeseries
+    args:
+      urlpath: 
+        /gpfs/scratch/ehpc01/bsc998159/a2wd/output/aqua-analysis/mn5-phase2/IFS-NEMO/a2wd/{{realization}}/timeseries/netcdf/atmosphere.timeseries.mn5-phase2.IFS-NEMO.a2wd.{{realization}}.*.{{freq}}.{{region}}.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      freq:
+        description: Parameter freq
+        default: monthly
+        type: str
+        allowed:
+        - monthly
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+      region:
+        description: Parameter region
+        default: global
+        type: str
+        allowed:
+        - global
+        - tropics
+        - europe
+  aqua-ocean-timeseries:
+    driver: netcdf
+    description: AQUA diagnostic ocean data for product timeseries
+    args:
+      urlpath: 
+        /gpfs/scratch/ehpc01/bsc998159/a2wd/output/aqua-analysis/mn5-phase2/IFS-NEMO/a2wd/{{realization}}/timeseries/netcdf/ocean.timeseries.mn5-phase2.IFS-NEMO.a2wd.{{realization}}.*.{{freq}}.{{region}}.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      freq:
+        description: Parameter freq
+        default: monthly
+        type: str
+        allowed:
+        - monthly
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+      region:
+        description: Parameter region
+        default: global
+        type: str
+        allowed:
+        - global
+        - southmidlatitudes
+  aqua-radiation-timeseries:
+    driver: netcdf
+    description: AQUA diagnostic radiation data for product timeseries
+    args:
+      urlpath: 
+        /gpfs/scratch/ehpc01/bsc998159/a2wd/output/aqua-analysis/mn5-phase2/IFS-NEMO/a2wd/{{realization}}/radiation/netcdf/radiation.timeseries.mn5-phase2.IFS-NEMO.a2wd.{{realization}}.*.{{freq}}.{{region}}.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      freq:
+        description: Parameter freq
+        default: monthly
+        type: str
+        allowed:
+        - monthly
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+      region:
+        description: Parameter region
+        default: global
+        type: str
+        allowed:
+        - global
+  aqua-atmosphere-seasonalcycles:
+    driver: netcdf
+    description: AQUA diagnostic atmosphere data for product seasonalcycles
+    args:
+      urlpath: 
+        /gpfs/scratch/ehpc01/bsc998159/a2wd/output/aqua-analysis/mn5-phase2/IFS-NEMO/a2wd/{{realization}}/timeseries/netcdf/atmosphere.seasonalcycles.mn5-phase2.IFS-NEMO.a2wd.{{realization}}.*.{{freq}}.{{region}}.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      freq:
+        description: Parameter freq
+        default: monthly
+        type: str
+        allowed:
+        - monthly
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+      region:
+        description: Parameter region
+        default: global
+        type: str
+        allowed:
+        - global
+  aqua-ocean-seasonalcycles:
+    driver: netcdf
+    description: AQUA diagnostic ocean data for product seasonalcycles
+    args:
+      urlpath: 
+        /gpfs/scratch/ehpc01/bsc998159/a2wd/output/aqua-analysis/mn5-phase2/IFS-NEMO/a2wd/{{realization}}/timeseries/netcdf/ocean.seasonalcycles.mn5-phase2.IFS-NEMO.a2wd.{{realization}}.*.{{freq}}.{{region}}.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+    metadata:
+      source_grid_name: false
+    parameters:
+      freq:
+        description: Parameter freq
+        default: monthly
+        type: str
+        allowed:
+        - monthly
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+      region:
+        description: Parameter region
+        default: global
+        type: str
+        allowed:
+        - global

--- a/catalogs/mn5-phase2/catalog/IFS-NEMO/a2xh.yaml
+++ b/catalogs/mn5-phase2/catalog/IFS-NEMO/a2xh.yaml
@@ -1,0 +1,342 @@
+sources:
+  hourly-hpz7-atm2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: cont  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2xh  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 151
+        levtype: sfc
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: D
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2xh , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [151, 165, 166, 167, 168, 207, 228164, 235035, 235040, 235043, 
+          235055]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2xh/a2xh.yaml
+  daily-hpz7-atm2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: cont  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2xh  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 172
+        levtype: sfc
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: D
+      savefreq: D
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2xh , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [172, 228002]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2xh/a2xh.yaml
+  monthly-hpz7-atm2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: cont  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2xh  # To be overwritten by workflow/config file
+        type: fc
+        stream: clmn
+        year: null
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 228004
+        levtype: sfc
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'ifs-nemo a2xh , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [228004, 235031, 235033, 235034, 235035, 235036, 235037, 235038,
+        235039, 235040, 235041, 235042, 235043, 235049, 235050, 235051, 235052, 
+          235053, 235055, 235151, 235165, 235166, 235288]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2xh/a2xh.yaml
+  6-hourly-hpz7-atm3d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: cont  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2xh  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 129
+        levtype: pl
+        levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
+            600, 700, 850, 925, 1000]
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: 6h
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2xh , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 
+          700, 850, 925, 1000]
+      variables: [129, 131, 132]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2xh/a2xh.yaml
+  monthly-hpz7-atm3d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: cont  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2xh  # To be overwritten by workflow/config file
+        type: fc
+        stream: clmn
+        year: null
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 235130
+        levtype: pl
+        levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
+            600, 700, 850, 925, 1000]
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'ifs-nemo a2xh , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 
+          700, 850, 925, 1000]
+      variables: [235130, 235131, 235132, 235133]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2xh/a2xh.yaml
+  daily-hpz7-oce2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: cont  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2xh  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 263000
+        levtype: o2d
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: D
+      savefreq: D
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2xh , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [263000, 263001, 263003, 263004, 263100, 263101, 263124]
+      source_grid_name: nemo-eORCA025-hpz7-nested-v3
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2xh/a2xh.yaml
+  monthly-hpz7-oce2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: cont  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2xh  # To be overwritten by workflow/config file
+        type: fc
+        stream: clmn
+        year: null
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 263000
+        levtype: o2d
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'ifs-nemo a2xh , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [263000, 263001, 263008, 263100, 263101, 263123]
+      source_grid_name: nemo-eORCA025-hpz7-nested-v3
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2xh/a2xh.yaml
+  monthly-hpz7-oce3d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: cont  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2xh  # To be overwritten by workflow/config file
+        type: fc
+        stream: clmn
+        year: null
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 263500
+        levtype: o3d
+        levelist: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+          19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
+          37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
+          55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72,
+          73, 74, 75]
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'ifs-nemo a2xh , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [0.5057600140571594, 1.5558552742004395, 2.6676816940307617, 
+          3.8562798500061035, 5.140361309051514, 6.543033599853516, 
+          8.09251880645752, 9.822750091552734, 11.773679733276367, 
+          13.99103832244873, 16.52532196044922, 19.42980194091797, 
+          22.75761604309082, 26.558300018310547, 30.874561309814453, 
+          35.740203857421875, 41.180023193359375, 47.21189498901367, 
+          53.85063552856445, 61.11283874511719, 69.02168273925781, 
+          77.61116027832031, 86.92942810058594, 97.04131317138672, 
+          108.03028106689453, 120.0, 133.07582092285156, 147.40625, 
+          163.16445922851562, 180.5499267578125, 199.7899627685547, 
+          221.14117431640625, 244.890625, 271.35638427734375, 300.88751220703125,
+        333.8628234863281, 370.6884765625, 411.7938537597656, 457.6256103515625, 
+          508.639892578125, 565.2922973632812, 628.0260009765625, 
+          697.2586669921875, 773.3682861328125, 856.678955078125, 
+          947.4478759765625, 1045.854248046875, 1151.9912109375, 
+          1265.8614501953125, 1387.376953125, 1516.3636474609375, 
+          1652.5684814453125, 1795.6707763671875, 1945.2955322265625, 
+          2101.026611328125, 2262.421630859375, 2429.025146484375, 
+          2600.38037109375, 2776.039306640625, 2955.5703125, 3138.56494140625, 
+          3324.640869140625, 3513.445556640625, 3704.65673828125, 
+          3897.98193359375, 4093.15869140625, 4289.95263671875, 4488.15478515625,
+        4687.5810546875, 4888.06982421875, 5089.478515625, 5291.68310546875, 
+          5494.5751953125, 5698.060546875, 5902.0576171875]
+      variables: [263500, 263501]
+      source_grid_name: nemo-eORCA025-hpz7-nested-3d-v3
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2xh/a2xh.yaml
+  hourly-hpz7-hl:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: cont  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2xh  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 131
+        levtype: hl
+        levelist: [100]
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: D
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2xh , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [100]
+      variables: [131, 132]
+      source_grid_name: hpz7
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2xh/a2xh.yaml
+  lra-r100-monthly:
+    driver: netcdf
+    description: LRA data monthly at r100
+    args:
+      urlpath: 
+        /gpfs/scratch/ehpc01/bsc998159/a2xh/output/LRA/fc0/mn5-phase2/IFS-NEMO/a2xh/r1/r100/monthly/mean/global/*a2xh_r1_r100_monthly_*.nc
+      chunks: {}
+      xarray_kwargs:
+        decode_times: true
+        combine: by_coords
+    metadata:
+      source_grid_name: lon-lat

--- a/catalogs/mn5-phase2/catalog/IFS-NEMO/a2xn.yaml
+++ b/catalogs/mn5-phase2/catalog/IFS-NEMO/a2xn.yaml
@@ -1,0 +1,330 @@
+sources:
+  hourly-hpz7-atm2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2xn  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 151
+        levtype: sfc
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: D
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2xn , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [151, 165, 166, 167, 168, 207, 228164, 235035, 235040, 235043, 
+          235055]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2xn/a2xn.yaml
+  daily-hpz7-atm2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2xn  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 172
+        levtype: sfc
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: D
+      savefreq: D
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2xn , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [172, 228002]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2xn/a2xn.yaml
+  monthly-hpz7-atm2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2xn  # To be overwritten by workflow/config file
+        type: fc
+        stream: clmn
+        year: null
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 228004
+        levtype: sfc
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'ifs-nemo a2xn , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [228004, 235031, 235033, 235034, 235035, 235036, 235037, 235038,
+        235039, 235040, 235041, 235042, 235043, 235049, 235050, 235051, 235052, 
+          235053, 235055, 235151, 235165, 235166, 235288]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2xn/a2xn.yaml
+  6-hourly-hpz7-atm3d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2xn  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 129
+        levtype: pl
+        levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
+            600, 700, 850, 925, 1000]
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: 6h
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2xn , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 
+          700, 850, 925, 1000]
+      variables: [129, 131, 132]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2xn/a2xn.yaml
+  monthly-hpz7-atm3d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2xn  # To be overwritten by workflow/config file
+        type: fc
+        stream: clmn
+        year: null
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 235130
+        levtype: pl
+        levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
+            600, 700, 850, 925, 1000]
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'ifs-nemo a2xn , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 
+          700, 850, 925, 1000]
+      variables: [235130, 235131, 235132, 235133]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2xn/a2xn.yaml
+  daily-hpz7-oce2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2xn  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 263000
+        levtype: o2d
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: D
+      savefreq: D
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2xn , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [263000, 263001, 263003, 263004, 263100, 263101, 263124]
+      source_grid_name: nemo-eORCA025-hpz7-nested-v3
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2xn/a2xn.yaml
+  monthly-hpz7-oce2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2xn  # To be overwritten by workflow/config file
+        type: fc
+        stream: clmn
+        year: null
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 263000
+        levtype: o2d
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'ifs-nemo a2xn , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [263000, 263001, 263008, 263100, 263101, 263123]
+      source_grid_name: nemo-eORCA025-hpz7-nested-v3
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2xn/a2xn.yaml
+  monthly-hpz7-oce3d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2xn  # To be overwritten by workflow/config file
+        type: fc
+        stream: clmn
+        year: null
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 263500
+        levtype: o3d
+        levelist: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+          19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
+          37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
+          55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72,
+          73, 74, 75]
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'ifs-nemo a2xn , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [0.5057600140571594, 1.5558552742004395, 2.6676816940307617, 
+          3.8562798500061035, 5.140361309051514, 6.543033599853516, 
+          8.09251880645752, 9.822750091552734, 11.773679733276367, 
+          13.99103832244873, 16.52532196044922, 19.42980194091797, 
+          22.75761604309082, 26.558300018310547, 30.874561309814453, 
+          35.740203857421875, 41.180023193359375, 47.21189498901367, 
+          53.85063552856445, 61.11283874511719, 69.02168273925781, 
+          77.61116027832031, 86.92942810058594, 97.04131317138672, 
+          108.03028106689453, 120.0, 133.07582092285156, 147.40625, 
+          163.16445922851562, 180.5499267578125, 199.7899627685547, 
+          221.14117431640625, 244.890625, 271.35638427734375, 300.88751220703125,
+        333.8628234863281, 370.6884765625, 411.7938537597656, 457.6256103515625, 
+          508.639892578125, 565.2922973632812, 628.0260009765625, 
+          697.2586669921875, 773.3682861328125, 856.678955078125, 
+          947.4478759765625, 1045.854248046875, 1151.9912109375, 
+          1265.8614501953125, 1387.376953125, 1516.3636474609375, 
+          1652.5684814453125, 1795.6707763671875, 1945.2955322265625, 
+          2101.026611328125, 2262.421630859375, 2429.025146484375, 
+          2600.38037109375, 2776.039306640625, 2955.5703125, 3138.56494140625, 
+          3324.640869140625, 3513.445556640625, 3704.65673828125, 
+          3897.98193359375, 4093.15869140625, 4289.95263671875, 4488.15478515625,
+        4687.5810546875, 4888.06982421875, 5089.478515625, 5291.68310546875, 
+          5494.5751953125, 5698.060546875, 5902.0576171875]
+      variables: [263500, 263501]
+      source_grid_name: nemo-eORCA025-hpz7-nested-3d-v3
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2xn/a2xn.yaml
+  hourly-hpz7-hl:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: baseline  # To be overwritten by workflow/config file
+        experiment: abrupt4xco2  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: a2xn  # To be overwritten by workflow/config file
+        type: fc
+        stream: clte
+        date: null
+        time: 0000
+        param: 131
+        levtype: hl
+        levelist: [100]
+      data_start_date: T0000
+      data_end_date: auto
+      chunks: D
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'ifs-nemo a2xn , grids: tco399 eORCA025'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [100]
+      variables: [131, 132]
+      source_grid_name: hpz7
+      fixer_name: climatedt-phase2-reduced
+      fdb_info_file: /gpfs/scratch/ehpc01/bsc998159/a2xn/a2xn.yaml

--- a/catalogs/mn5-phase2/catalog/IFS-NEMO/main.yaml
+++ b/catalogs/mn5-phase2/catalog/IFS-NEMO/main.yaml
@@ -249,3 +249,39 @@ sources:
     driver: yaml_file_cat
     args:
       path: '{{CATALOG_DIR}}/a24z.yaml'
+  a2vu:
+    description: '"ifs-nemo a2vu , grids: tco399 eORCA025"'
+    metadata:
+      author: bsc998159
+      maintainer: not specified
+      machine: MN5
+      expid: a2vu
+      resolution_atm: tco399
+      resolution_oce: eORCA025
+      forcing: control
+      start: ''
+      dashboard:
+        menu: a2vu
+        resolution_id: MR
+        note: null
+    driver: yaml_file_cat
+    args:
+      path: '{{CATALOG_DIR}}/a2vu.yaml'
+  a2vh:
+    description: '"ifs-nemo a2vh , grids: tco399 eORCA025"'
+    metadata:
+      author: bsc998159
+      maintainer: not specified
+      machine: MN5
+      expid: a2vh
+      resolution_atm: tco399
+      resolution_oce: eORCA025
+      forcing: control
+      start: ''
+      dashboard:
+        menu: a2vh
+        resolution_id: MR
+        note: null
+    driver: yaml_file_cat
+    args:
+      path: '{{CATALOG_DIR}}/a2vh.yaml'

--- a/catalogs/mn5-phase2/catalog/IFS-NEMO/main.yaml
+++ b/catalogs/mn5-phase2/catalog/IFS-NEMO/main.yaml
@@ -285,3 +285,39 @@ sources:
     driver: yaml_file_cat
     args:
       path: '{{CATALOG_DIR}}/a2vh.yaml'
+  a2wb:
+    description: '"ifs-nemo a2wb , grids: tco399 eORCA025"'
+    metadata:
+      author: bsc998159
+      maintainer: not specified
+      machine: MN5
+      expid: a2wb
+      resolution_atm: tco399
+      resolution_oce: eORCA025
+      forcing: abrupt4xco2
+      start: ''
+      dashboard:
+        menu: a2wb
+        resolution_id: MR
+        note: null
+    driver: yaml_file_cat
+    args:
+      path: '{{CATALOG_DIR}}/a2wb.yaml'
+  a2wd:
+    description: '"ifs-nemo a2wd , grids: tco2559 eORCA12"'
+    metadata:
+      author: bsc998159
+      maintainer: not specified
+      machine: MN5
+      expid: a2wd
+      resolution_atm: tco2559
+      resolution_oce: eORCA12
+      forcing: abrupt4xco2
+      start: ''
+      dashboard:
+        menu: a2wd
+        resolution_id: HR
+        note: null
+    driver: yaml_file_cat
+    args:
+      path: '{{CATALOG_DIR}}/a2wd.yaml'

--- a/catalogs/mn5-phase2/catalog/IFS-NEMO/main.yaml
+++ b/catalogs/mn5-phase2/catalog/IFS-NEMO/main.yaml
@@ -321,3 +321,39 @@ sources:
     driver: yaml_file_cat
     args:
       path: '{{CATALOG_DIR}}/a2wd.yaml'
+  a2xh:
+    description: '"Continuation from a2vu ifs-nemo a2xh , grids: tco399 eORCA025"'
+    metadata:
+      author: bsc998159
+      maintainer: not specified
+      machine: MN5
+      expid: a2xh
+      resolution_atm: tco399
+      resolution_oce: eORCA025
+      forcing: control
+      start: ''
+      dashboard:
+        menu: a2xh
+        resolution_id: MR
+        note: null
+    driver: yaml_file_cat
+    args:
+      path: '{{CATALOG_DIR}}/a2xh.yaml'
+  a2xn:
+    description: '"ifs-nemo a2xn , grids: tco399 eORCA025"'
+    metadata:
+      author: bsc998159
+      maintainer: not specified
+      machine: MN5
+      expid: a2xn
+      resolution_atm: tco399
+      resolution_oce: eORCA025
+      forcing: abrupt4xco2
+      start: ''
+      dashboard:
+        menu: a2xn
+        resolution_id: MR
+        note: null
+    driver: yaml_file_cat
+    args:
+      path: '{{CATALOG_DIR}}/a2xn.yaml'


### PR DESCRIPTION
## PR description:

Catalogs for 4xCO2 IFS-NEMO runs and potentially the SSP126 scenario (this hasn't started yet)

Although these are partially working, the LRA_GENERATOR (+AQUA_ANALSYIS) not yet, likely due to the use of the AQUA version v0.18.0 and its interaction with the reduced portfolio tailored templates.

So there’s still some work to do, I suggest we keep this PR pending for now.

## Issues closed by this pull request:

Close 

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready" label.

 - [ ] General README is updated if a new catalog is added.
 - [ ] Fixes are added to AQUA if new fixes are needed.
 - [ ] Grids are added to AQUA if new grids are needed.
 - [ ] Specific catalog README file is updated or added if needed (note of caution, errata, work to be done, etc.).
 - [ ] Tests are passing.
