### PR TITLE
Add year>2400 example

### DIFF
--- a/catalogs/ci/catalog/IFS/test-tco79.yaml
+++ b/catalogs/ci/catalog/IFS/test-tco79.yaml
@@ -71,7 +71,15 @@ sources:
       - '{{ TEST_PATH }}/IFS/long/regridded_r18x9.nc'
     description: coarse IFS data 1y
     driver: netcdf
-
+  long400:
+    metadata:
+      fixer_name: ifs-ci-test
+      source_grid_name: lon-lat
+    args:
+      urlpath:
+      - '{{ TEST_PATH }}/IFS/long/regridded_r18x9_400.nc'
+    description: coarse IFS data 1y after year 2400
+    driver: netcdf
   long-cftime:
     metadata:
       fixer_name: ifs-ci-test


### PR DESCRIPTION
## PR description:

This adds an example source where date is beyond 2400 to test pandas capabilities with microseconds.
See also https://github.com/DestinE-Climate-DT/AQUA/pull/2638

----

 - [x] Tests are passing.
