### PR TITLE
New LUMI path and ECMWF ERA5 duplication

### DIFF
--- a/catalogs/climatedt-gen2/machine.yaml
+++ b/catalogs/climatedt-gen2/machine.yaml
@@ -1,13 +1,13 @@
 lumi:
   paths:
-    grids: /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/grids
-    weights: /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/weights
-    areas: /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/areas
+    grids: /pfs/lustrep4/projappl/project_465002727/aqua/aqua-dvc/grids
+    weights: /pfs/lustrep4/projappl/project_465002727/aqua/aqua-dvc/weights
+    areas: /pfs/lustrep4/projappl/project_465002727/aqua/aqua-dvc/areas
   intake:
     # where LRA data is stored
-    LRA_PATH: /pfs/lustrep3/appl/local/climatedt/data/AQUA/LRA/climatedt-o25.1
+    LRA_PATH: /pfs/lustrep4/projappl/project_465002727/aqua/LRA/climatedt-o25.1
     # where Zarr data is stored
-    ZARR_PATH: /pfs/lustrep3/appl/local/climatedt/data/AQUA/LRA/climatedt-gen2
+    ZARR_PATH: /pfs/lustrep4/projappl/project_465002727/aqua/LRA/climatedt-gen2
 MN5:
   paths:
     grids: /gpfs/projects/ehpc01/data/AQUA/aqua-dvc/grids

--- a/catalogs/climatedt-o25.1/machine.yaml
+++ b/catalogs/climatedt-o25.1/machine.yaml
@@ -1,11 +1,11 @@
 lumi:
   paths:
-    grids: /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/grids
-    weights: /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/weights
-    areas: /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/areas
+    grids: /pfs/lustrep4/projappl/project_465002727/aqua/aqua-dvc/grids
+    weights: /pfs/lustrep4/projappl/project_465002727/aqua/aqua-dvc/weights
+    areas: /pfs/lustrep4/projappl/project_465002727/aqua/aqua-dvc/areas
   intake:
     # where LRA data is stored
-    LRA_PATH: /pfs/lustrep3/appl/local/climatedt/data/AQUA/LRA/climatedt-o25.1
+    LRA_PATH: /pfs/lustrep4/projappl/project_465002727/aqua/LRA/climatedt-o25.1
 MN5:
   paths:
     grids: /gpfs/projects/ehpc01/data/AQUA/aqua-dvc/grids

--- a/catalogs/climatedt-phase1/machine.yaml
+++ b/catalogs/climatedt-phase1/machine.yaml
@@ -1,13 +1,13 @@
 lumi:
   paths:
-    grids: /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/grids
-    weights: /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/weights
-    areas: /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/areas
+    grids: /pfs/lustrep4/projappl/project_465002727/aqua/aqua-dvc/grids
+    weights: /pfs/lustrep4/projappl/project_465002727/aqua/aqua-dvc/weights
+    areas: /pfs/lustrep4/projappl/project_465002727/aqua/aqua-dvc/areas
   intake:
     # where LRA data is stored (available in all the machines listed)
-    LRA_PATH: /pfs/lustrep3/appl/local/climatedt/data/AQUA/LRA/climatedt-phase1
+    LRA_PATH: /pfs/lustrep4/projappl/project_465002727/aqua/LRA/climatedt-phase1
     # where DROP data is stored (available in all the machines listed)
-    DROP_PATH: /pfs/lustrep3/appl/local/climatedt/data/AQUA/DROP/climatedt-phase1
+    DROP_PATH: /pfs/lustrep4/projappl/project_465002727/aqua/DROP/climatedt-phase1
     # where the FDB schema is stored (available only on lumi)
     FDB_PATH: /pfs/lustrep3/appl/local/destine
     # where the historical FDB data is stored (available only on lumi)

--- a/catalogs/nextgems4/machine.yaml
+++ b/catalogs/nextgems4/machine.yaml
@@ -14,7 +14,7 @@ lumi:
     weights: /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/weights
     areas: /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/areas
   intake:
-    LRA_NEXTGEMS: /pfs/lustrep3/appl/local/climatedt/data/AQUA/LRA-nextgems4
+    LRA_NEXTGEMS: /pfs/lustrep3/appl/local/climatedt/data/AQUA/LRA/nextgems4
     FDB_PATH: null
     ECCODES_PATH: /pfs/lustrep3/appl/local/climatedt/data/AQUA/eccodes
     OUTPUT_AQUA_PATH: /pfs/lustrep3/projappl/project_465000454/jvonhar/aqua-analysis/output/pre_computed_aqua_analysis

--- a/catalogs/nextgems4/machine.yaml
+++ b/catalogs/nextgems4/machine.yaml
@@ -10,11 +10,11 @@ levante:
     OUTPUT_AQUA_PATH: /work/ab0995/a270260/pre_computed_aqua_analysis
 lumi:
   paths:
-    grids: /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/grids
-    weights: /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/weights
-    areas: /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/areas
+    grids: /pfs/lustrep4/projappl/project_465002727/aqua/aqua-dvc/grids
+    weights: /pfs/lustrep4/projappl/project_465002727/aqua/aqua-dvc/weights
+    areas: /pfs/lustrep4/projappl/project_465002727/aqua/aqua-dvc/areas
   intake:
-    LRA_NEXTGEMS: /pfs/lustrep3/appl/local/climatedt/data/AQUA/LRA/nextgems4
+    LRA_NEXTGEMS: /pfs/lustrep4/projappl/project_465002727/aqua/LRA/nextgems4
     FDB_PATH: null
     ECCODES_PATH: /pfs/lustrep3/appl/local/climatedt/data/AQUA/eccodes
     OUTPUT_AQUA_PATH: /pfs/lustrep3/projappl/project_465000454/jvonhar/aqua-analysis/output/pre_computed_aqua_analysis

--- a/catalogs/obs/catalog/ECMWF/README.md
+++ b/catalogs/obs/catalog/ECMWF/README.md
@@ -1,0 +1,31 @@
+# ERA5 information
+
+Two dataset are avalaible:
+- arco-era5: Complete dataset offered by Google via cloud storage. Currently not maintained, for testing purposes
+- era5: official AQUA ClimateDT ERA5 compact repo. it includes monthly data from 1940 to 2024 of a subselection of variables.
+
+For monthly data the dafault format is netcdf. A `monthly-zarr` zarr source is also available, which may be considerably faster for some applications.
+
+## How to update
+
+ERA5 dataset is dowloaded from CDS making use of a simple tool python tool `CDS retriever`. 
+It requires ECMWF api to be installed, please check the documentation: https://github.com/oloapinivad/CDS-retriever
+The tool can be run in `update` mode so that when a new complete year is available, it can be retrieved in a single shot. 
+
+Given that folder structure is slightly different than the one used automatically, a wrapper is prepared here `wrapper_cds.sh`: 
+this basic tool will loop on the variable availalble, will launch the download and cat the files to create a new updated one
+Manual removing of old files has to be done before finalizing the update. Please double check with attention what is done, and the proper folders since 
+it is not a straightforward operation
+
+Please check the property of the `CDS retriever` configuration file  and the path location. Original updated have been done on Levante DKRZ.
+
+Always double check  timestamp of fluxes variables, since they might need to be aligned to 00:00:00 to avoid issue with xarray.  
+
+## Conversion to zarr
+
+A `nc2zarr` configuration file is avalable in the `scripts` subdirectory. Please refer to the AQUA documentation for instructions.
+
+---------
+Last updated by 
+- Paolo Davini, CNR, Oct 2025
+- Jost von Hardenberg, PoliTO, Oct 2025

--- a/catalogs/obs/catalog/ECMWF/arco-era5.yaml
+++ b/catalogs/obs/catalog/ECMWF/arco-era5.yaml
@@ -1,0 +1,13 @@
+sources:
+  hourly-r025: 
+    description: ERA5 hourly data from 1940 to 2022 with ARCO ERA5 Google cloud
+    driver: zarr
+    args:
+      urlpath: 'gs://gcp-public-data-arco-era5/ar/full_37-1h-0p25deg-chunk-1.zarr-v3'
+      consolidated: True
+      storage_options: 
+        token: 'anon'
+      chunks: null
+    metadata:
+      source_grid_name: longitude-latitude
+      fixer_name: era5-arco

--- a/catalogs/obs/catalog/ECMWF/era5.yaml
+++ b/catalogs/obs/catalog/ECMWF/era5.yaml
@@ -1,0 +1,45 @@
+plugins:
+  source:
+    - module: intake_xarray
+
+sources:
+  monthly-zarr: &monthly-zarr
+    description: ERA5 monthly data from 1940 to 2024 in zarr
+    driver: zarr
+    metadata:
+      source_grid_name: era5-r025s
+      fixer_name: ERA5-destine-v1
+    args:
+      consolidated: True
+      urlpath: '{{DATA_PATH}}/ERA5/zarr/era5_monthly_1940-2024.zarr'
+      chunks:
+        time: 12
+
+  monthly-netcdf: &monthly-netcdf
+    description: ERA5 monthly data from 1940 to 2024 in netcdf
+    driver: netcdf
+    metadata:
+      source_grid_name: era5-r025s
+      fixer_name: ERA5-destine-v1
+    args:
+      urlpath: '{{DVC_PATH}}/ERA5/mon/ERA5_*_mon_full*.nc'
+      chunks: 
+        time: 12
+      xarray_kwargs:
+        decode_times: True
+
+  monthly:
+    <<: *monthly-netcdf
+
+  daily:
+    description: ERA5 daily data from 1940 to 2022 (test)
+    driver: netcdf
+    metadata:
+      source_grid_name: era5-r025s
+      fixer_name: ERA5-daily-destine-v1
+    args:
+      urlpath: '{{DATA_PATH}}/ERA5/day/ERA5_*_day_full*.nc'
+      chunks: 
+        time: 30
+      xarray_kwargs:
+        decode_times: True

--- a/catalogs/obs/catalog/ECMWF/main.yaml
+++ b/catalogs/obs/catalog/ECMWF/main.yaml
@@ -1,0 +1,11 @@
+sources:
+  era5:
+    description: AQUA compact version of ERA5 data
+    driver: yaml_file_cat
+    args:
+        path: "{{CATALOG_DIR}}/era5.yaml"
+  arco-era5:
+    description: ERA5 hourly data from with ARCO ERA5 Google cloud
+    driver: yaml_file_cat
+    args:
+        path: "{{CATALOG_DIR}}/arco-era5.yaml"

--- a/catalogs/obs/catalog/ECMWF/scripts/era5_monthly.yml
+++ b/catalogs/obs/catalog/ECMWF/scripts/era5_monthly.yml
@@ -1,0 +1,25 @@
+# Run with: nc2zarr -vv -c era5_monthly.yml
+# When providing a list of directories use the "-s name" option
+
+input:
+  paths:
+     - /pfs/lustrep3/appl/local/climatedt/data/AQUA/datasets/ERA5/mon/ERA5*.nc
+
+#  decode_cf: true
+  multi_file: true
+
+process:
+  rechunk:
+    '*':
+      lon: null  # no chunking for lon dim in all variables
+      lat: null  # no chunking for lon dim in all variables
+      time: 1    # chunk size 1 for time dim in all variables
+    lon: null    # no chunking for lon dim in lon variable
+    lat: null    # no chunking for lat dim in lat variable
+    time: 1
+
+output:
+  path: /pfs/lustrep3/appl/local/climatedt/data/AQUA/datasets/ERA5/zarr/era5_monthly_1940-2024.zarr
+  overwrite: false
+  consolidated: true
+  append_dim: time

--- a/catalogs/obs/catalog/ECMWF/scripts/wrapper_cds.sh
+++ b/catalogs/obs/catalog/ECMWF/scripts/wrapper_cds.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# This script works only for monthly files, it is run on Levante, and 
+# looks for availalbe data and then extend it using CDS features
+# it will not remove older files
+# it might be more convienent to not run the update flag, and manually cat the files
+
+STOREDIR='/work/bb1153/b382076/ERA5'
+TMPDIR='/work/bb1153/b382076/ERA5'
+CDSPATH=/home/b/b382076/CDS-retriever
+CDSconfig=/home/b/b382076/CDS-retriever/config.yaml
+
+year1=1940
+year2=2024
+
+varlist=($(for f in $STOREDIR/mon/ERA5_*.nc; do
+    basename "$f" | sed -E 's/^ERA5_([^_]+(_[^_]+)*)_mon_.*$/\1/'
+done))
+
+# define which vars are 3D
+threeD_vars=("temperature" "u_component_of_wind" "v_component_of_wind" "specific_humidity")
+
+for variable in "${varlist[@]}" ; do
+	if [[ " ${threeD_vars[*]} " == *" $variable "* ]]; then
+        	levelout=plev8
+        else
+        	levelout=sfc
+        fi
+	echo $variable
+	CDSDIR=$STOREDIR/${variable}/mon
+	mkdir -p $CDSDIR
+	cp $STOREDIR/mon/*${variable}*nc $CDSDIR
+	python3 $CDSPATH/ERA5_retrieve_postproc.py -c "$CDSconfig" -v "$variable" --outputdir $STOREDIR --tmpdir $TMPDIR --levelout $levelout -u
+	cp $CDSDIR/*${variable}*nc $STOREDIR/mon
+	rm -rf $CDSDIR
+done
+
+# this path has to be adjusted
+DIR=$STOREDIR/mon
+
+# fix to enforce time axis for fluxes variables
+varlist="evaporation surface_net_solar_radiation_clear_sky surface_net_solar_radiation surface_net_thermal_radiation_clear_sky surface_net_thermal_radiation surface_sensible_heat_flux surface_solar_radiation_downwards surface_thermal_radiation_downwards top_net_solar_radiation_clear_sky top_net_solar_radiation top_net_thermal_radiation_clear_sky top_net_thermal_radiation total_precipitation surface_latent_heat_flux "
+for var in $varlist ; do
+	file=$DIR/ERA5_${var}_mon_full_sfc_${year1}-${year2}.nc
+	echo $file
+	cdo -f nc4 -z zip settunits,hours -settaxis,${year1}-01-01,00:00:00,1mon $file $DIR/test.nc
+	mv $DIR/test.nc $file
+done
+
+
+

--- a/catalogs/obs/machine.yaml
+++ b/catalogs/obs/machine.yaml
@@ -16,12 +16,12 @@ levante:
     DVC_PATH: /work/bb1153/b382289/data/aqua-dvc/datasets
 lumi:
   paths:
-    grids: /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/grids
-    weights: /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/weights
-    areas: /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/areas
+    grids: /pfs/lustrep4/projappl/project_465002727/aqua/aqua-dvc/grids
+    weights: /pfs/lustrep4/projappl/project_465002727/aqua/aqua-dvc/weights
+    areas: /pfs/lustrep4/projappl/project_465002727/aqua/aqua-dvc/areas
   intake:
-    DATA_PATH: /pfs/lustrep3/appl/local/climatedt/data/AQUA/datasets
-    DVC_PATH: /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/datasets
+    DATA_PATH: /pfs/lustrep4/projappl/project_465002727/aqua/datasets
+    DVC_PATH: /pfs/lustrep4/projappl/project_465002727/aqua/aqua-dvc/datasets
 MN5:
   paths:
     grids: /gpfs/projects/ehpc01/data/AQUA/aqua-dvc/grids


### PR DESCRIPTION
## PR description:

This update the path of the LUMI DVC for OBS following the new development project. However, this is not ready yet. 

It also introduces a clone of ERA5-era5 as ECMWF-era5 dataset so that it would be possible to avoid manual hacking when plotting.

 - [ ] Tests are passing.
