### PR TITLE
Add ERA5 Earth Data Hub

### DIFF
--- a/catalogs/ci/machine.yaml
+++ b/catalogs/ci/machine.yaml
@@ -15,3 +15,8 @@ lumi:
     TEST_PATH: ./AQUA_tests/models
     # test FDB HOME on Lumi on padavini user
     FDB_HOME: /pfs/lustrep3/projappl/project_465000454/padavini/FDB-TEST 
+pamir:
+  paths:
+    grids: /Users/paolo/Desktop/AQUA/AQUA_tests/grids
+  intake:
+    TEST_PATH: /Users/paolo/Desktop/AQUA/AQUA_tests/models

--- a/catalogs/ci/machine.yaml
+++ b/catalogs/ci/machine.yaml
@@ -15,8 +15,3 @@ lumi:
     TEST_PATH: ./AQUA_tests/models
     # test FDB HOME on Lumi on padavini user
     FDB_HOME: /pfs/lustrep3/projappl/project_465000454/padavini/FDB-TEST 
-pamir:
-  paths:
-    grids: /Users/paolo/Desktop/AQUA/AQUA_tests/grids
-  intake:
-    TEST_PATH: /Users/paolo/Desktop/AQUA/AQUA_tests/models

--- a/catalogs/obs/catalog.yaml
+++ b/catalogs/obs/catalog.yaml
@@ -40,6 +40,11 @@ sources:
     driver: yaml_file_cat
     args:
       path: "{{CATALOG_DIR}}/catalog/ERA5/main.yaml"
+  ECMWF:
+    description: ECMWF ERA5 reanalysis data
+    driver: yaml_file_cat
+    args:
+      path: "{{CATALOG_DIR}}/catalog/ECMWF/main.yaml"
   GPM:
     description: Global Precipitation Measurement
     driver: yaml_file_cat

--- a/catalogs/obs/catalog/ECMWF/earth-era5.yaml
+++ b/catalogs/obs/catalog/ECMWF/earth-era5.yaml
@@ -3,12 +3,12 @@ sources:
     description: ERA5 hourly data from 1940 to 2026 with ARCO Earth Data Hub on single levels
     driver: zarr
     args:
-      urlpath: "https://data.earthdatahub.destine.eu/era5/reanalysis-era5-single-levels-v0.zarr"
+      urlpath: "https://api.earthdatahub.destine.eu/era5/reanalysis-era5-single-levels-v0.zarr"
       consolidated: True
       storage_options: 
         client_kwargs:
           trust_env: True
-      chunks: null
+      chunks: auto
     metadata:
       source_grid_name: False
       fixer_name: era5-earth-data-hub
@@ -16,12 +16,12 @@ sources:
     description: ERA5 hourly data from 1940 to 2026 with ARCO Earth Data Hub on pressure levels
     driver: zarr
     args:
-      urlpath: "https://data.earthdatahub.destine.eu/era5/reanalysis-era5-pressure-levels-v0.zarr"
+      urlpath: "https://api.earthdatahub.destine.eu/era5/reanalysis-era5-pressure-levels-v0.zarr"
       consolidated: True
       storage_options: 
         client_kwargs:
           trust_env: True
-      chunks: null
+      chunks: auto
     metadata:
       source_grid_name: False
       fixer_name: era5-earth-data-hub
@@ -29,13 +29,13 @@ sources:
     description: ERA5 daily data from 1940 to 2026 with ARCO Earth Data Hub on single levels
     driver: zarr
     args:
-      urlpath: "https://data.earthdatahub.destine.eu/era5/era5-single-levels-atmosphere-daily-utc-v0.zarr"
+      urlpath: "https://api.earthdatahub.destine.eu/era5/era5-single-levels-atmosphere-daily-utc-v0.zarr"
       consolidated: True
       storage_options: 
         client_kwargs:
           trust_env: True
-      chunks: null
+      chunks: auto
     metadata:
-      source_grid_name: False
+      source_grid_name: lon-lat
       fixer_name: era5-earth-data-hub
   

--- a/catalogs/obs/catalog/ECMWF/earth-era5.yaml
+++ b/catalogs/obs/catalog/ECMWF/earth-era5.yaml
@@ -10,7 +10,7 @@ sources:
           trust_env: True
       chunks: auto
     metadata:
-      source_grid_name: False
+      source_grid_name: lon-lat
       fixer_name: era5-earth-data-hub
   hourly-r025-pl: 
     description: ERA5 hourly data from 1940 to 2026 with ARCO Earth Data Hub on pressure levels
@@ -23,7 +23,7 @@ sources:
           trust_env: True
       chunks: auto
     metadata:
-      source_grid_name: False
+      source_grid_name: lon-lat
       fixer_name: era5-earth-data-hub
   daily-r025-sfc: 
     description: ERA5 daily data from 1940 to 2026 with ARCO Earth Data Hub on single levels

--- a/catalogs/obs/catalog/ECMWF/earth-era5.yaml
+++ b/catalogs/obs/catalog/ECMWF/earth-era5.yaml
@@ -1,0 +1,41 @@
+sources:
+  hourly-r025-sfc: 
+    description: ERA5 hourly data from 1940 to 2026 with ARCO Earth Data Hub on single levels
+    driver: zarr
+    args:
+      urlpath: "https://data.earthdatahub.destine.eu/era5/reanalysis-era5-single-levels-v0.zarr"
+      consolidated: True
+      storage_options: 
+        client_kwargs:
+          trust_env: True
+      chunks: null
+    metadata:
+      source_grid_name: False
+      fixer_name: era5-earth-data-hub
+  hourly-r025-pl: 
+    description: ERA5 hourly data from 1940 to 2026 with ARCO Earth Data Hub on pressure levels
+    driver: zarr
+    args:
+      urlpath: "https://data.earthdatahub.destine.eu/era5/reanalysis-era5-pressure-levels-v0.zarr"
+      consolidated: True
+      storage_options: 
+        client_kwargs:
+          trust_env: True
+      chunks: null
+    metadata:
+      source_grid_name: False
+      fixer_name: era5-earth-data-hub
+  daily-r025-sfc: 
+    description: ERA5 daily data from 1940 to 2026 with ARCO Earth Data Hub on single levels
+    driver: zarr
+    args:
+      urlpath: "https://data.earthdatahub.destine.eu/era5/era5-single-levels-atmosphere-daily-utc-v0.zarr"
+      consolidated: True
+      storage_options: 
+        client_kwargs:
+          trust_env: True
+      chunks: null
+    metadata:
+      source_grid_name: False
+      fixer_name: era5-earth-data-hub
+  

--- a/catalogs/obs/catalog/ECMWF/main.yaml
+++ b/catalogs/obs/catalog/ECMWF/main.yaml
@@ -9,3 +9,8 @@ sources:
     driver: yaml_file_cat
     args:
         path: "{{CATALOG_DIR}}/arco-era5.yaml"
+  earth-era5:
+    description: ERA5 hourly data from with ARCO Earth Data Hub Google cloud
+    driver: yaml_file_cat
+    args:
+        path: "{{CATALOG_DIR}}/earth-era5.yaml"


### PR DESCRIPTION
## PR description:

This PR add the Earth Data Hub to the ECMWF catalog. Unfortunately, the regridding option is not working since we create the grid, likely to some issue with the metadata.  For now it works only with https://github.com/DestinE-Climate-DT/AQUA/pull/2871


 - [ ] General README is updated if a new catalog is added.
 - [ ] Fixes are added to AQUA if new fixes are needed.
 - [ ] Grids are added to AQUA if new grids are needed.
 - [ ] Specific catalog README file is updated or added if needed (note of caution, errata, work to be done, etc.).
 - [ ] Tests are passing.
