### PR TITLE
Chunk for zarr MSWEP sources

### DIFF
--- a/catalogs/obs/catalog/MSWEP/v2.8.yaml
+++ b/catalogs/obs/catalog/MSWEP/v2.8.yaml
@@ -38,6 +38,7 @@ sources:
       fixer_name: MSWEP-default
     args:
       consolidated: True
+      chunks: auto
       urlpath: 
       - '{{DATA_PATH}}/MSWEP/v2.8/zarr/mswep280.past-nrt.daily.zarr'
 

--- a/catalogs/obs/catalog/MSWEP/v2.8.yaml
+++ b/catalogs/obs/catalog/MSWEP/v2.8.yaml
@@ -12,6 +12,7 @@ sources:
       fixer_name: MSWEP-default
     args:
       consolidated: False
+      chunks: auto
       urlpath: 
       - '{{DVC_PATH}}/MSWEP/v2.8/zarr/mswep280.past-nrt.monthly.zarr'
   
@@ -48,6 +49,8 @@ sources:
       fixer_name: MSWEP-default
     args:
       consolidated: True
+      chunks:
+        time: 240
       urlpath: 
       - '{{DATA_PATH}}/MSWEP/v2.8/zarr/mswep280.past-nrt.3hourly.zarr'
 


### PR DESCRIPTION
## PR description:

Actual zarr sources were not possible to open due to missing chunking, requiring an actual load in memory of the entire chunk (responsible the unit_fixer in the Fixer). The solution is to introduce a chunk, also auto one is working, for the zarr MSWEP sources.

 - [x] Tests are passing.
