### PR TITLE
Fix DATA_PATH for lumi obs

### DIFF
--- a/catalogs/obs/machine.yaml
+++ b/catalogs/obs/machine.yaml
@@ -20,7 +20,7 @@ lumi:
     weights: /pfs/lustrep4/projappl/project_465002727/aqua/aqua-dvc/weights
     areas: /pfs/lustrep4/projappl/project_465002727/aqua/aqua-dvc/areas
   intake:
-    DATA_PATH: /pfs/lustrep4/projappl/project_465002727/aqua/datasets
+    DATA_PATH: /pfs/lustrep4/projappl/project_465002727/aqua/aqua-datasets
     DVC_PATH: /pfs/lustrep4/projappl/project_465002727/aqua/aqua-dvc/datasets
 MN5:
   paths:


### PR DESCRIPTION
## PR description:

DATA_PATH set for lumi was not existent, while the new one was sync to the new project, therefore I'm updating the variable in the machine.yaml file.

 - [x] Tests are passing.
