### PR TITLE
[OBS] update path for new ceres data to 2025

### DIFF
--- a/catalogs/obs/catalog/CERES/README.md
+++ b/catalogs/obs/catalog/CERES/README.md
@@ -13,8 +13,13 @@ The datasets are available for download at: [https://ceres.larc.nasa.gov/Data/#]
 
 The AQUA team currently utilizes the following CERES datasets:
 
-- **EBAF-Surface**: Energy Balanced and Filled surface radiation data
-- **EBAF-TOA**: Energy Balanced and Filled Top-of-Atmosphere radiation data
+- **EBAF-Surface** (`ebaf-sfc421`): Energy Balanced and Filled surface radiation data,
+  covering March 2000 to March 2026
+- **EBAF-TOA** (`ebaf-toa421`): Energy Balanced and Filled Top-of-Atmosphere radiation data,
+  covering March 2000 to May 2026
+
+The two series end in different months on purpose: NASA releases EBAF-TOA ahead of
+EBAF-Surface, so at any given time the Surface product lags by a couple of months.
 
 The current implementation uses **version v4.2.1**, which is the most recent version available, 
 although previous versions are also accessible.
@@ -23,17 +28,18 @@ although previous versions are also accessible.
 
 **SYN1deg** ([https://ceres.larc.nasa.gov/documents/DQ_summaries/CERES_SYN1deg_Ed4A_DQS.pdf](https://ceres.larc.nasa.gov/documents/DQ_summaries/CERES_SYN1deg_Ed4A_DQS.pdf)): 
 Synoptic radiative fluxes and clouds computed hourly on a 1-degree grid, combining CERES and 
-geostationary satellite data. These datasets are currently not updated to 2025.
+geostationary satellite data. Our copy stops at the end of 2021 (1 January 2001 to
+31 December 2021) and has not been extended since.
 
 ### Download Process
 
 Due to the apparent absence of programmatic download options (e.g., `wget`), the AQUA team 
 downloaded the data manually through the web interface. 
 
-Given the 2GB maximum download limit, the EBAF-Surface data covering March 2000 to June 2025 
-was downloaded in two separate batches and subsequently merged using `cdo mergetime`. This 
-two-step process was only necessary for the Surface data, as the EBAF-TOA dataset for the 
+Given the 2GB maximum download limit, the EBAF-Surface data covering March 2000 to March 2026
+was downloaded in two separate batches and subsequently merged using `cdo mergetime`. This
+two-step process was only necessary for the Surface data, as the EBAF-TOA dataset for the
 entire time period remained under the 2GB threshold.
 
 ---------
-Last updated by Marco Cadau, Politecnico di Torino, Oct 2025
+Last updated by Marco Cadau, Politecnico di Torino, Sep 2026

--- a/catalogs/obs/catalog/CERES/ebaf-sfc421.yaml
+++ b/catalogs/obs/catalog/CERES/ebaf-sfc421.yaml
@@ -4,13 +4,13 @@ plugins:
 
 sources:
   monthly:
-    description: CERES EBAF SFC Ed4.2.1 from 2000-03 to 2025-06
+    description: CERES EBAF SFC Ed4.2.1 from 2000-03 to 2026-03
     driver: netcdf
     metadata:
       source_grid_name: lon-lat
       fixer_name: ceres-ebaf-sfc-destine-v1
     args:
-      urlpath: '{{DVC_PATH}}/CERES/EBAF_v4.2.1/CERES_EBAF_Edition4.2.1_MONTHLY_200003-202506.nc'
+      urlpath: '{{DVC_PATH}}/CERES/EBAF_v4.2.1/CERES_EBAF_Edition4.2.1_MONTHLY_200003-202603.nc'
       chunks: {}
       xarray_kwargs:
         decode_times: True

--- a/catalogs/obs/catalog/CERES/ebaf-toa421.yaml
+++ b/catalogs/obs/catalog/CERES/ebaf-toa421.yaml
@@ -4,13 +4,13 @@ plugins:
 
 sources:
   monthly:
-    description: CERES EBAF TOA Ed4.2.1 from 2000-03 to 2025-06
+    description: CERES EBAF TOA Ed4.2.1 from 2000-03 to 2026-05
     driver: netcdf
     metadata:
       fixer_name: ceres-ebaf-toa-destine-v1
       source_grid_name: lon-lat
     args:
-      urlpath: '{{DVC_PATH}}/CERES/EBAF_v4.2.1/CERES_EBAF-TOA_Edition4.2.1_MONTHLY_200003-202506.nc'
+      urlpath: '{{DVC_PATH}}/CERES/EBAF_v4.2.1/CERES_EBAF-TOA_Edition4.2.1_MONTHLY_200003-202605.nc'
       chunks: {}
       xarray_kwargs:
         decode_times: True

--- a/catalogs/obs/catalog/CERES/main.yaml
+++ b/catalogs/obs/catalog/CERES/main.yaml
@@ -25,12 +25,12 @@ sources:
     args:
       path: "{{CATALOG_DIR}}/syn-toa41.yaml"
   ebaf-sfc421:
-    description: CERES-EBAF v4.2.1 updated version up to 2025-06
+    description: CERES-EBAF v4.2.1 updated version up to 2026-03
     driver: yaml_file_cat
     args:
       path: "{{CATALOG_DIR}}/ebaf-sfc421.yaml"
   ebaf-toa421:
-    description: CERES-EBAF v4.2.1 updated version up to 2025-06
+    description: CERES-EBAF v4.2.1 updated version up to 2026-05
     driver: yaml_file_cat
     args:
       path: "{{CATALOG_DIR}}/ebaf-toa421.yaml"


### PR DESCRIPTION
## PR description:

CERES 4.2.1 has been extended to full 2025 (and beyond: sfc updated to March 2026 and TOA to May 2026). Data is available on Lumi on `/pfs/lustrep3/appl/local/climatedt/data/AQUA/datasets-new/ceres` and has to included on DVC. No major changes are required since this is a mere dataset extension

----

 - [ ] General README is updated if a new catalog is added.
 - [ ] Fixes are added to AQUA if new fixes are needed.
 - [ ] Grids are added to AQUA if new grids are needed.
 - [ ] Specific catalog README file is updated or added if needed (note of caution, errata, work to be done, etc.).
 - [ ] Tests are passing.
