### PR TITLE
[OBS] update EN4 paths to 2025

### DIFF
--- a/catalogs/obs/catalog/EN4/README.md
+++ b/catalogs/obs/catalog/EN4/README.md
@@ -1,93 +1,101 @@
 # The EN4 datasets
 
-EN4 is a oceanic data set from the Met Office Hadley Centre. EN4 official documentation is 
-available [here] (https://www.metoffice.gov.uk/hadobs/en4/EN.4.2.2_Product_User_Guide_v1.0.pdf)
-
-Data are downloaded from the AQUA team from 1950 to 2024, and the AQUA ocean diagnostics set 
-widely utilises the following variables on the analysis:
+EN4 is an oceanic data set from the Met Office Hadley Centre, documented
+[here](https://www.metoffice.gov.uk/hadobs/en4/EN.4.2.2_Product_User_Guide_v1.0.pdf).
+Data cover 1950 to 2025. The AQUA ocean diagnostics use:
 
 - Sea water salinity (`so`) and its uncertainty (`so_uncertainty`)
 - Sea water potential temperature (`thetao`) and its uncertainty (`thetao_uncertainty`)
 
-Variable names follow the CMOR standard.
+Variable names follow the CMOR standard. Two sources are available: `monthly` (the default,
+a zarr store) and `monthly-netcdf`. **Both must be kept at the same end year**: `monthly` is an
+alias of `monthly-zarr`, so updating only the netcdf leaves every diagnostic on the old data.
 
-The resulting netcdf data have been converted to a zarr store using nc2zarr and the configuration file `scripts/en4-monthly.yml`.
-Both zarr (the dafault `monthly` source) and netcdf (`monthly-netcdf`) sources are available.
+## Extending the time series
 
-We provide a script, named `EN4_management.sh` in the `scripts` folder, where the data timeseries 
-can be extended after 2024. The `bash` script is structured ad follows: 
+`scripts/EN4_management.sh` downloads a new year from the Met Office, extracts `so` and `thetao`
+with their uncertainties, renames to CMOR, regrids to `EN4_target_grid.txt`, and merges the result
+with the existing series. Edit at the top of the script:
 
-### Script structure
+```bash
+START_YEAR=2026        # year to download
+END_YEAR=2026
+WORK_DIR=".../datasets-new/en4/download"    # scratch
+FINAL_DIR=".../datasets-new/en4"            # staging
+```
 
-The script performs the following operations:
+The previous full series must already be in `FINAL_DIR` (the script merges against it and uses it
+as reference for the coordinate check), so copy it there from DVC first.
 
-1. **Grid configuration**: Uses `EN4_target_grid.txt` (located in the same directory) to regrid 
-   new data to match existing data grid
-2. **Data download**: Downloads annual ZIP files from Met Office for specified years
-3. **Variable processing**: For each monthly file, extracts and processes `so` and `thetao` 
-   (with uncertainties)
-4. **Post-processing**: Renames variables, removes problematic attributes, converts time to float, 
-   and applies regridding
-5. **Temporal merge**: Combines monthly files into annual datasets
-6. **Final merge**: Merges new data with existing historical data
-7. **Data transfer**: Moves final files from working directory to the AQUA operational directory 
-   on LUMI (`FINAL_DIR`)
+Only complete years are processed: if a month is missing the whole year is skipped. The download
+URL uses the `en4-2-1` directory even for EN.4.2.2 files — that is correct, not a typo.
 
-### How to use
+The script's final merge produces `<var>_EN4_complete_<date>.nc`. For the 2025 extension the
+concatenation was instead done explicitly, which is faster and preserves the netcdf4/zip encoding:
 
-1. **Edit the script parameters**:
-   ```bash
-   START_YEAR=2025  # First year to download
-   END_YEAR=2025    # Last year to download
-   WORK_DIR="/users/cadaumar/en4_download"  # Working directory (adjust as needed)
-   ```
+```bash
+cdo -f nc4 -z zip cat so-EN4-1950-2024.nc so_EN4_2025_2025.nc so-EN4-1950-2025.nc
+```
 
-2. **Run the script**:
-   ```bash
-   bash Climate-DT-catalog/catalogs/obs/catalog/EN4/scripts/EN4_management.sh
-   ```
+Either way, rename the result to `<var>-EN4-1950-<year>.nc` and check it before going further:
 
-3. **Output files**: The script generates:
-   - `so_EN4_YYYY_YYYY.nc` - New salinity data
-   - `thetao_EN4_YYYY_YYYY.nc` - New temperature data
-   - `so_EN4_complete_YYYYMMDD.nc` - Complete merged salinity dataset
-   - `thetao_EN4_complete_YYYYMMDD.nc` - Complete merged temperature dataset
+```bash
+cdo ntime so-EN4-1950-YYYY.nc          # 12 * number of years
+cdo showtimestamp so-EN4-1950-YYYY.nc | tail -1
+```
 
-4. **Verify and backup** (IMPORTANT):
-   - Check that new files are correct (use the coordinate comparison section in the script)
-   - **Before replacing operational files**, create a backup:
-     ```bash
-     cd /pfs/lustrep3/appl/local/climatedt/data/AQUA/datasets/EN4
-     mkdir -p backup
-     cp so-1950_2024.nc backup/
-     cp thetao-1950_2024.nc backup/
-     ```
-   - Rename the new complete files to match the operational naming scheme:
-     ```bash
-     mv so_EN4_complete_YYYYMMDD.nc so-1950_2025.nc  # Update end year
-     mv thetao_EN4_complete_YYYYMMDD.nc thetao-1950_2025.nc
-     ```
+## Regenerating the zarr store
 
-### Important notes
+Required at every update, since `monthly` is the zarr. `nc2zarr` is not in the AQUA environment;
+on LUMI it is a container-wrapper (see `AQUA/cli/nc2zarr/README.md`):
 
-- **Complete years only**: The script processes only complete years (all 12 months must be 
-available)
-- **Automatic validation**: If any monthly file is missing, the entire year is skipped
-- **Grid consistency**: New data is automatically regridded to match the existing grid
-- **Uncertainties required**: Both main variables and their uncertainties must be present in 
-source files
-- **Two-stage processing**: Data is first downloaded and processed in `WORK_DIR`, then moved to 
-`FINAL_DIR` only after successful processing
-- **Always backup**: Create backups before replacing operational datasets
+```bash
+export PATH=/pfs/lustrep3/projappl/project_465000454/jvonhar/containers/nc2zarr/bin:$PATH
+nc2zarr -vv -c scripts/en4_monthly.yml
+```
 
-### Requirements
+Update input paths, output store name and end year in `scripts/en4_monthly.yml` first. The run
+takes about 7 minutes for the full 1950-2025 series, so a login node is enough — no SLURM needed.
+`output.overwrite` is deliberately `false`: a re-run stops instead of clobbering an existing store,
+so delete the output directory first if you need to start over.
 
-- `cdo` (Climate Data Operators)
-- `nco` (NetCDF Operators: `ncatted`, `ncrename`, `ncap2`, `ncdump`)
-- `wget`, `unzip`
-- Sufficient disk space in working directory (~1GB per year)
+Chunking must stay `time: 1` with no chunking in space, matching the existing store.
+
+## Publishing
+
+`v4.2.2.dvc` tracks the whole `v4.2.2` directory as a single object, so netcdf and zarr must both
+be in place before `dvc add` — otherwise two add/push cycles are needed.
+
+In the working DVC repo (`/pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc`):
+
+```bash
+cd datasets/EN4/v4.2.2
+cp <staging>/*-EN4-1950-YYYY.nc netcdf/ && cp netcdf/*-EN4-1950-YYYY.nc .
+cp -r <staging>/EN4.v422.1950-YYYY.clev.zarr zarr/
+rm netcdf/*-1950-<prev>.nc ./*-1950-<prev>.nc && rm -r zarr/EN4.v422.1950-<prev>.clev.zarr
+cd /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc
+dvc add datasets/EN4/v4.2.2 && dvc push -r ecmwf_climatedt
+```
+
+Removing the previous year is safe as long as you have verified that the new netcdf contains it
+verbatim (it is a `cdo cat` of the old series plus the new year); the old version stays recoverable
+from the DVC cache through the previous `v4.2.2.dvc` in the aqua-dvc git history.
+
+Then commit the new `v4.2.2.dvc` on a branch of `aqua-dvc`, and update `v4.2.2.yaml` here (both
+`monthly-zarr` and `monthly-netcdf`).
+
+**The catalog does not read from the working repo.** `machine.yaml` resolves `{{DVC_PATH}}` to a
+separate deployment checkout per machine — on LUMI `/pfs/lustrep4/projappl/project_465002727/aqua/aqua-dvc/datasets`
+for `lumi`, and `.../input_data/applications/AQUA_O-26.1_v1.0/datasets` for `lumi-o26.1`. Each one
+needs `git pull` + `dvc pull` after the push, before this PR is merged, or EN4 breaks there.
+
+## Requirements
+
+`cdo`, `nco` (`ncatted`, `ncrename`, `ncap2`), `wget`, `unzip`, `nc2zarr` (container-wrapper on
+LUMI). About 1 GB of scratch per year, 13 GB for the full zarr store.
 
 ---------
-Last updated by 
+Last updated by
+- Marco Cadau, Politecnico di Torino, Sep 2026
 - Marco Cadau, Politecnico di Torino, Oct 2025
 - Jost von Hardenberg, PoliTO, Oct 2025

--- a/catalogs/obs/catalog/EN4/scripts/EN4_management.sh
+++ b/catalogs/obs/catalog/EN4/scripts/EN4_management.sh
@@ -130,8 +130,8 @@ process_variable() {
 
 # Variables configuration
 BASE_URL="https://www.metoffice.gov.uk/hadobs/en4/data/en4-2-1"
-WORK_DIR="/users/cadaumar/en4_download" #TO BE CHANGED AS NEEDED
-FINAL_DIR="/pfs/lustrep3/appl/local/climatedt/data/AQUA/datasets/EN4"
+WORK_DIR="/pfs/lustrep3/appl/local/climatedt/data/AQUA/datasets-new/en4/download" #TO BE CHANGED AS NEEDED
+FINAL_DIR="/pfs/lustrep3/appl/local/climatedt/data/AQUA/datasets-new/en4"
 START_YEAR=2025
 END_YEAR=2025
 
@@ -441,7 +441,7 @@ compare_coordinates() {
 }
 
 # Find files to compare
-reference_so="$FINAL_DIR/so-1950_2022.nc"
+reference_so="$FINAL_DIR/so-EN4-1950_2024.nc"
 
 # Check what SO files we have
 if [ -n "${final_merged_so:-}" ] && [ -f "$FINAL_DIR/$final_merged_so" ]; then

--- a/catalogs/obs/catalog/EN4/scripts/EN4_management.sh
+++ b/catalogs/obs/catalog/EN4/scripts/EN4_management.sh
@@ -441,7 +441,7 @@ compare_coordinates() {
 }
 
 # Find files to compare
-reference_so="$FINAL_DIR/so-EN4-1950_2024.nc"
+reference_so="$FINAL_DIR/so-EN4-1950-$((START_YEAR-1)).nc"
 
 # Check what SO files we have
 if [ -n "${final_merged_so:-}" ] && [ -f "$FINAL_DIR/$final_merged_so" ]; then

--- a/catalogs/obs/catalog/EN4/scripts/en4_monthly.yml
+++ b/catalogs/obs/catalog/EN4/scripts/en4_monthly.yml
@@ -3,8 +3,8 @@
 
 input:
   paths:
-     - /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/datasets/EN4/v4.2.2/thetao-EN4-1950-2024.nc
-     - /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/datasets/EN4/v4.2.2/so-EN4-1950-2024.nc
+     - /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/datasets/EN4/v4.2.2/thetao-EN4-1950-2025.nc
+     - /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/datasets/EN4/v4.2.2/so-EN4-1950-2025.nc
 
 #  decode_cf: true
   multi_file: true

--- a/catalogs/obs/catalog/EN4/scripts/en4_monthly.yml
+++ b/catalogs/obs/catalog/EN4/scripts/en4_monthly.yml
@@ -1,10 +1,14 @@
-# Run with: nc2zarr -vv -c era5_monthly.yml
+# Run with: nc2zarr -vv -c en4_monthly.yml
 # When providing a list of directories use the "-s name" option
+#
+# Input is the DVC-tracked netcdf; the store is written to the staging area and
+# copied under aqua-dvc only afterwards, so that netcdf and zarr can be registered
+# with a single `dvc add`. Never point `output.path` at a DVC-tracked store.
 
 input:
   paths:
-     - /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/datasets/EN4/v4.2.2/thetao-EN4-1950-2025.nc
-     - /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/datasets/EN4/v4.2.2/so-EN4-1950-2025.nc
+     - /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/datasets/EN4/v4.2.2/netcdf/thetao-EN4-1950-2025.nc
+     - /pfs/lustrep3/appl/local/climatedt/data/AQUA/aqua-dvc/datasets/EN4/v4.2.2/netcdf/so-EN4-1950-2025.nc
 
 #  decode_cf: true
   multi_file: true
@@ -22,7 +26,6 @@ process:
     lev: null
 
 output:
-  path: /pfs/lustrep3/appl/local/climatedt/data/AQUA/datasets/EN4/v4.2.2/EN4.v422.1950-2024.clev.zarr
-  overwrite: true
+  path: /pfs/lustrep3/appl/local/climatedt/data/AQUA/datasets-new/en4/EN4.v422.1950-2025.clev.zarr
+  overwrite: false
   consolidated: true
-  append_dim: time

--- a/catalogs/obs/catalog/EN4/v4.2.2.yaml
+++ b/catalogs/obs/catalog/EN4/v4.2.2.yaml
@@ -1,13 +1,13 @@
 sources: 
   monthly-zarr: &monthly-zarr
-    description: EN4 data v4.2.2_g10 version from 1950 to 2024 in zarr format
+    description: EN4 data v4.2.2_g10 version from 1950 to 2025 in zarr format
     driver: zarr
     metadata:
       source_grid_name: en4
       fixer_name: EN4-default
     args:
       consolidated: True
-      urlpath: '{{DVC_PATH}}/EN4/v4.2.2/zarr/EN4.v422.1950-2024.clev.zarr'
+      urlpath: '{{DVC_PATH}}/EN4/v4.2.2/zarr/EN4.v422.1950-2025.clev.zarr'
 
   monthly-netcdf: &monthly-netcdf
     description: EN4 data v4.2.2_g10 version from 1950 to 2025 in netcdf4 zip format

--- a/catalogs/obs/catalog/EN4/v4.2.2.yaml
+++ b/catalogs/obs/catalog/EN4/v4.2.2.yaml
@@ -10,13 +10,13 @@ sources:
       urlpath: '{{DVC_PATH}}/EN4/v4.2.2/zarr/EN4.v422.1950-2024.clev.zarr'
 
   monthly-netcdf: &monthly-netcdf
-    description: EN4 data v4.2.2_g10 version from 1950 to 2024 in netcdf format
+    description: EN4 data v4.2.2_g10 version from 1950 to 2025 in netcdf4 zip format
     driver: netcdf
     metadata:
       source_grid_name: en4
       fixer_name: EN4-default
     args:
-      urlpath: '{{DVC_PATH}}/EN4/v4.2.2/netcdf/*EN4-1950-2024.nc'
+      urlpath: '{{DVC_PATH}}/EN4/v4.2.2/netcdf/*EN4-1950-2025.nc'
       chunks: 
         time: 12
       xarray_kwargs:


### PR DESCRIPTION
## PR description:

This extendes EN4 datasets to 2025. of course we also need to update DVC


- [x] Download new data
- [x] Document the retrieve of data (if data are lost in order to restore them asap)
- [x] Do a temporary backup of old data
- [x] Substitute data on Lumi
- [x] Adapt the catalog
- [x] Add to DVC
- [ ] Test the diagnostic (if possible)
- [ ] Run test

----

 - [ ] Specific catalog README file is updated or added if needed (note of caution, errata, work to be done, etc.).
 - [ ] Tests are passing.
