### PR TITLE
[OBS] update esa-cci to 2024 and 2025

### DIFF
--- a/catalogs/obs/catalog/ESA-CCI-L4/README.md
+++ b/catalogs/obs/catalog/ESA-CCI-L4/README.md
@@ -2,10 +2,13 @@
 
 Current AQUA supported dataset is v3.0.1.
 
-Retrieved from CEDA archives https://data.ceda.ac.uk/neodc/eocis/data/global_and_regional/sea_surface_temperature/CDR_v3/Analysis/L4/v3.0.1. 
+Data are available from CDS at https://cds.climate.copernicus.eu/datasets/satellite-sea-surface-temperature?tab=download by fecthing the combined product L4. 
+
+This covers regularly updated data from CDS which extend the CEDA archives which was available until 2024-07.
+
 License can be found here: https://artefacts.ceda.ac.uk/licences/specific_licences/esacci_sst_terms_and_conditions_v2.pdf.
 
-Only monthly average are available. For 2022-2023 the dataset is Interim. From 07/2024 no data is available.
+Only monthly average are available in aqua.
 
 Two sources are available:
 - native-monthly: Spatial resolution is 0.05 deg. 
@@ -15,5 +18,5 @@ Two sources are available:
 
 > Please note that the script uses an old folder structure and some rearrangament might be required if you want to download the data again
 
-A nice AI-based script to retrieve and create the monthly average separated per variable is available in the folder `retrieve_esacci.py`
+A nice AI-based script to retrieve and create the monthly average separated per variable is available in the folder `retrieve_c3s.py`, which superseed an older script used to download the data from CEDA directly. 
 It is a bit of an overkill but should do everything required.

--- a/catalogs/obs/catalog/ESA-CCI-L4/scripts/retrieve_c3s.py
+++ b/catalogs/obs/catalog/ESA-CCI-L4/scripts/retrieve_c3s.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Download CERES/C3S SST data from CDS month-by-month and package into
+compressed yearly NetCDF4 files."""
+import argparse
+import glob
+import os
+import subprocess
+import zipfile
+import cdsapi
+import logging
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+DATASET = "satellite-sea-surface-temperature"
+MONTHS = [f"{m:02d}" for m in range(1, 13)]
+DAYS = [f"{d:02d}" for d in range(1, 32)]
+# Variables to extract as separate monthly-mean files during post-processing
+VARIABLES = ["analysed_sst", "sea_ice_fraction"]
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Download CERES/C3S SST data from CDS month-by-month and "
+        "package into compressed yearly NetCDF4 files."
+    )
+    p.add_argument("--start", type=int, required=True, help="First year to download (e.g., 2020)")
+    p.add_argument("--end", type=int, required=True, help="Last year to download (e.g., 2024)")
+    p.add_argument("--output-dir", type=str, default="./sst_data", help="Target output directory")
+    return p.parse_args()
+
+
+def build_request(year: str, month: str) -> dict:
+    return {
+        "variable": "all",
+        "processinglevel": "level_4",
+        "sensor_on_satellite": "combined_product",
+        "version": "3_0",
+        "temporal_resolution": "daily",
+        "year": [year],
+        "month": [month],
+        "day": DAYS,
+    }
+
+
+def unzip_if_needed(filepath: str):
+    """CDS sometimes delivers a .nc-named file that's actually a zip archive
+    containing one .nc per day. Detect, extract, and merge into a single
+    monthly file at the same path (in-place, using cdo)."""
+    if not zipfile.is_zipfile(filepath):
+        return
+
+    extract_dir = filepath + "_extracted"
+    os.makedirs(extract_dir, exist_ok=True)
+    with zipfile.ZipFile(filepath) as zf:
+        names = [n for n in zf.namelist() if n.endswith(".nc")]
+        zf.extractall(extract_dir, members=names)
+
+    daily_files = sorted(os.path.join(extract_dir, n) for n in names)
+    os.remove(filepath)
+
+    if len(daily_files) == 1:
+        os.replace(daily_files[0], filepath)
+    else:
+        cdo_cmd = ["cdo", "-f", "nc4", "cat", *daily_files, filepath.replace(".zip", ".nc")]
+        result = subprocess.run(cdo_cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(f"cdo failed merging daily files for {filepath}:\n{result.stderr}")
+
+    for f in daily_files:
+        if os.path.exists(f):
+            os.remove(f)
+    os.rmdir(extract_dir)
+
+
+def download_year(client: cdsapi.Client, year: int, temp_dir: str) -> bool:
+    """Download all months for a year. Returns True if all 12 succeeded."""
+    year_str = str(year)
+    os.makedirs(temp_dir, exist_ok=True)
+
+    for month in MONTHS:
+        monthly_file = os.path.join(temp_dir, f"sst_{year_str}_{month}.zip")
+        logger.info(f" Fetching data for {year_str}-{month}...")
+        if os.path.exists(monthly_file):
+            logger.info(f" Month {month} already downloaded, skipping...")
+        else:
+            try:
+                client.retrieve(DATASET, build_request(year_str, month), monthly_file)
+            except Exception as e:
+                        logger.error(f" [ERROR] Failed to download {year_str}-{month}: {e}")
+                        return False
+        logger.info(f" Unzipping and merging {year_str}-{month}...")
+        try:
+            unzip_if_needed(monthly_file)
+        except Exception as e:
+            logger.error(f" [ERROR] Failed to unzip {year_str}-{month}: {e}")
+            return False
+
+    downloaded = sorted(glob.glob(os.path.join(temp_dir, "sst_*.nc")))
+    return len(downloaded) == 12
+
+
+
+def package_year(temp_dir: str, output_dir: str, year: int, variables=VARIABLES) -> bool:
+    """Merge monthly files for the year, then compute monthly means per
+    variable into variable-specific subfolders via CDO."""
+    logger.info(f"Processing year {year}")
+ 
+    files = sorted(glob.glob(os.path.join(str(temp_dir), f"sst_{year}_*.nc")))
+    if len(files) != 12:
+        logger.warning(f"Expected 12 monthly files for {year}, found {len(files)}, skipping")
+        return False
+ 
+    # Skip entirely if every variable's output already exists
+    all_exist = all(
+        os.path.exists(os.path.join(output_dir, var, f"sst_monthly_{year}_{var}.nc"))
+        for var in variables
+    )
+    if all_exist:
+        logger.info(f"All target files for {year} already exist, skipping processing")
+        return True
+ 
+    temp_merged = os.path.join(str(temp_dir), f"temp_merged_{year}.nc")
+    try:
+        if os.path.exists(temp_merged):
+            os.remove(temp_merged)
+            logger.info(f"Removed existing temporary file: {temp_merged}")
+ 
+        logger.info(f"Merging monthly files for {year}...")
+        merge_cmd = ["cdo", "mergetime", *files, temp_merged]
+        result = subprocess.run(merge_cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            logger.error(f"CDO merge failed for {year}: {result.stderr}")
+            return False
+ 
+        success = True
+        for var in variables:
+            var_dir = os.path.join(str(output_dir), var)
+            os.makedirs(var_dir, exist_ok=True)
+            var_output_file = os.path.join(var_dir, f"ESA-CCI-L4_v3.0.1_monthly_{year}_{var}.nc")
+ 
+            if os.path.exists(var_output_file):
+                logger.info(f"Target file already exists, skipping: {var_output_file}")
+                continue
+ 
+            logger.info(f"Calculating monthly averages for {year}, variable: {var}...")
+            monthly_cmd = [
+                "cdo", "-f", "nc4", "-z", "zip",
+                "settime,00:00:00", "-setday,1", "-monmean", f"-selname,{var}",
+                temp_merged, var_output_file,
+            ]
+            result = subprocess.run(monthly_cmd, capture_output=True, text=True)
+            if result.returncode != 0:
+                logger.error(f"CDO monthly average failed for {year}, variable {var}: {result.stderr}")
+                success = False
+                continue
+            logger.info(f"Created monthly averages file: {var_output_file}")
+
+            logger.info("Producing r360x180 version...")
+            r360x180_file = os.path.join(var_dir, f"ESA-CCI-L4_v3.0.1_monthly_{year}_{var}_r360x180.nc")
+            remap_cmd = [
+                "cdo", "-f", "nc4", "-z", "zip",
+                "remapcon,r360x180", var_output_file, r360x180_file
+            ]
+            result = subprocess.run(remap_cmd, capture_output=True, text=True)
+            if result.returncode != 0:
+                logger.error(f"CDO remap failed for {year}, variable {var}: {result.stderr}")
+                success = False
+                continue
+            logger.info(f"Created remapped file: {r360x180_file}")
+ 
+        return success
+    except Exception as e:
+        logger.error(f"Error processing {year}: {e}")
+        return False
+    finally:
+        if os.path.exists(temp_merged):
+            os.remove(temp_merged)
+
+
+def process_year(client: cdsapi.Client, year: int, output_dir: str):
+    year_str = str(year)
+    yearly_output_file = os.path.join(str(output_dir), f"sst_global_{year_str}.nc")
+
+    if os.path.exists(yearly_output_file):
+        logger.info(f"--> Year {year_str} already packaged ({yearly_output_file}). Skipping...")
+        return
+
+    logger.info(f"\n==========================================")
+    logger.info(f" Processing Year: {year_str}")
+    logger.info(f"==========================================")
+
+    temp_dir = os.path.join(str(output_dir), f"temp_{year_str}")
+    download_year(client, year, temp_dir)
+    package_year(temp_dir, str(output_dir), year, VARIABLES)
+
+
+def main():
+    args = parse_args()
+    os.makedirs(args.output_dir, exist_ok=True)
+    client = cdsapi.Client()
+
+    for year in range(args.start, args.end + 1):
+        process_year(client, year, args.output_dir)
+
+    logger.info("\nProcessing finished!")
+
+
+if __name__ == "__main__":
+    main()

--- a/catalogs/obs/catalog/ESA-CCI-L4/v301.yaml
+++ b/catalogs/obs/catalog/ESA-CCI-L4/v301.yaml
@@ -1,6 +1,6 @@
 sources:
   native-monthly:
-    description: ESA-CCI-L4 monthly data v3.0.1 from 1980 to 2023
+    description: ESA-CCI-L4 monthly data v3.0.1 from 1980 to 2025
     driver: netcdf
     metadata:
       source_grid_name: lon-lat
@@ -12,7 +12,7 @@ sources:
       xarray_kwargs:
         decode_times: True
   r100-monthly:
-    description: ESA-CCI-L4 monthly data v3.0.1 from 1980 to 2023
+    description: ESA-CCI-L4 monthly data v3.0.1 from 1980 to 2025
     driver: netcdf
     metadata:
       source_grid_name: lon-lat


### PR DESCRIPTION
## PR description:

Update the ESA-CCI-L4 using the new C3S service, and retrieve 2024 and 2025. Data are availble in `/pfs/lustrep3/appl/local/climatedt/data/AQUA/datasets-new/esa` and must be yet updated to DVC

## Issues closed by this pull request:

Close 

----

Please leave the checkboxes that apply to this pull request.
If you find a missing checkbox, please add it to the list.
Make sure to complete the checkboxes before applying the "ready" label.

 - [ ] General README is updated if a new catalog is added.
 - [ ] Fixes are added to AQUA if new fixes are needed.
 - [ ] Grids are added to AQUA if new grids are needed.
 - [ ] Specific catalog README file is updated or added if needed (note of caution, errata, work to be done, etc.).
 - [ ] Tests are passing.
