### PR TITLE
fixer for AVISO ssh variable

### DIFF
--- a/catalogs/obs/catalog/AVISO/vDT2024.yaml
+++ b/catalogs/obs/catalog/AVISO/vDT2024.yaml
@@ -8,6 +8,7 @@ sources:
       driver: zarr
       metadata:
         source_grid_name: aviso
+        fixer_name: ssh-adt
       args:
         consolidated: True
         urlpath: 


### PR DESCRIPTION
The SSH variable of AVISO dataset in observational catalog requires this fixer. 