### PR TITLE
MSWEPv316_test and upgrade of MSWEP v280 to 2025

### DIFF
--- a/catalogs/obs/catalog/MSWEP/README.md
+++ b/catalogs/obs/catalog/MSWEP/README.md
@@ -55,7 +55,11 @@ Another particularity is the fact that while the "Past" 3-hourly data are intege
 ### Rechunking
 
 The original data have a chunking also in space which is not adequate for AQUA. All netcdf data (and zarr consequently) were preprocessed, rechunking them with the script `scripts/rechunk.sh`.
+For monthly NRT data, needed for routine data extension, there is a dedicated script `scripts/rechunk_nrt_monthly.sh` which can be used to generate the rechunked files from the original NRT netcdf files and takes care also of setting the correct time axis.
 
+### Validation of new data extension
+
+In order to validate the new data extension, we suggest to create also years already available and to use the cdo command `cdo diff file_old.nc file_new.nc` to check that the new files are identical to the old ones.
 
 ### Zarr
 

--- a/catalogs/obs/catalog/MSWEP/README.md
+++ b/catalogs/obs/catalog/MSWEP/README.md
@@ -1,3 +1,28 @@
+# MSWEP v3.16 information
+
+Along with a new algorithm, MSWEP V3 incorporates new data sources, reduces drizzle overestimation, and minimizes peak underestimation compared to V2.
+It is described by this paper: 10.48550/arXiv.2602.01436.
+
+### Download data
+
+For the v3 dataset download, a script named `download.sh` is provided in the `scripts` folder. It will download the data from the MSWEP Google Drive and store it a chosen location.
+Time frequency and type of data (NRT or Past) can be selected while using the script. Please check the script for more details.
+
+### Final note
+
+According to the MSWEP team:
+
+> We identified spurious precipitation trend artifacts in V3.15/V3.16 associ-
+> ated with IMERG and GSMaP. Both datasets exhibit a systematic increase in precipitation from
+> 2015 onward, likely related to the transition to GPM; as a result, MSWEP V3.15/V3.16 shows ar-
+> tificially low precipitation during 2000–2015 relative to the preceding and subsequent periods.
+> In the next MSWEP version, we will likely replace IMERG and GSMaP with CMORPH-CDR, which
+> does not show this behavior. This issue affects both the uncorrected and gauge-corrected
+> historical products (Past_nogauge and Past) of V3.15/V3.16. For users who require reliable
+> trend estimates, we recommend using V2.80 for 1979–2021 until the issue is resolved
+
+For this reason we leave download scripts, but we are still relying on the v2.8 dataset for AQUA.
+
 # MSWEP v2.8 information
 
 MSWEP is a global precipitation product with a 3‑hourly 0.1° resolution available from 1979 to ~3 hours from real-time. 
@@ -54,8 +79,3 @@ rclone sync -v  --drive-shared-with-me GoogleDrive:/MSWEP_V280/Past/Monthly/ /YO
 ````
 typically only the second one will be needed, since the "Past" archive does not change. Similarly for `Daily` and `3hourly` data.
 You will then need to postprocess the data to generate the rechunked netcdf files as described above.
-
-
-
-
-

--- a/catalogs/obs/catalog/MSWEP/scripts/download.sh
+++ b/catalogs/obs/catalog/MSWEP/scripts/download.sh
@@ -21,10 +21,10 @@
 
 set -e
 
-RESOLUTION="3hourly"
+RESOLUTION="monthly"
 ARCHIVE="Past"
-VERSION="MSWEP_V3"
-OUTDIR=""
+VERSION="MSWEP_V316_test"
+OUTDIR="/scratch/project_465002727/mnurisso/MSWEP/v3.16"
 
 usage() {
     echo "Usage: $0 -o <outdir> [-r 3hourly|daily|monthly] [-a Past|NRT] [-v <gdrive-version-folder>]"

--- a/catalogs/obs/catalog/MSWEP/scripts/download.sh
+++ b/catalogs/obs/catalog/MSWEP/scripts/download.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# Download MSWEP v3 data from the GoogleDrive shared by the GloH2O maintainers.
+#
+# Access to the GoogleDrive folder must be requested beforehand by following the
+# "Apply" link on https://www.gloh2o.org/mswep/. Once access is granted, the
+# GoogleDrive remote must be configured for rclone (see
+# https://rclone.org/drive/), and the mamba/conda environment "rclone" must
+# provide the `rclone` executable.
+#
+# Usage:
+#   ./download.sh -r <resolution> -a <archive> -o <outdir> [-v <version>]
+#
+#   -r  resolution: one of "3hourly", "daily", "monthly" (default: 3hourly)
+#   -a  archive: one of "Past", "NRT" (default: Past)
+#   -o  output directory where data will be synced (required)
+#   -v  MSWEP GoogleDrive version folder name (default: MSWEP_V3)
+#
+# Example:
+#   ./download.sh -r 3hourly -a NRT -o /aqua/work/users/MSWEP/MSWEP_V3/3hourly/NRT
+
+set -e
+
+RESOLUTION="3hourly"
+ARCHIVE="Past"
+VERSION="MSWEP_V3"
+OUTDIR=""
+
+usage() {
+    echo "Usage: $0 -o <outdir> [-r 3hourly|daily|monthly] [-a Past|NRT] [-v <gdrive-version-folder>]"
+    exit 1
+}
+
+while getopts "r:a:o:v:h" opt; do
+    case "$opt" in
+        r) RESOLUTION="$OPTARG" ;;
+        a) ARCHIVE="$OPTARG" ;;
+        o) OUTDIR="$OPTARG" ;;
+        v) VERSION="$OPTARG" ;;
+        h) usage ;;
+        *) usage ;;
+    esac
+done
+
+if [ -z "$OUTDIR" ]; then
+    echo "Error: output directory (-o) is required"
+    usage
+fi
+
+case "$RESOLUTION" in
+    3hourly) REMOTE_DIR="3hourly" ;;
+    daily) REMOTE_DIR="Daily" ;;
+    monthly) REMOTE_DIR="Monthly" ;;
+    *) echo "Error: invalid resolution '$RESOLUTION'"; usage ;;
+esac
+
+case "$ARCHIVE" in
+    Past|NRT) ;;
+    *) echo "Error: invalid archive '$ARCHIVE'"; usage ;;
+esac
+
+# >>> mamba initialize >>>
+# !! Contents within this block are managed by 'mamba shell init' !!
+export MAMBA_EXE='/aqua/work/users/mnurisso/miniforge3/bin/mamba';
+export MAMBA_ROOT_PREFIX='/aqua/work/users/mnurisso/miniforge3';
+__mamba_setup="$("$MAMBA_EXE" shell hook --shell bash --root-prefix "$MAMBA_ROOT_PREFIX" 2> /dev/null)"
+if [ $? -eq 0 ]; then
+    eval "$__mamba_setup"
+else
+    alias mamba="$MAMBA_EXE"  # Fallback on help from mamba activate
+fi
+mamba activate rclone
+# <<< mamba initialize <<<
+
+mkdir -p "$OUTDIR"
+
+echo "Downloading MSWEP ${VERSION} ${ARCHIVE}/${REMOTE_DIR} into ${OUTDIR}"
+
+rclone sync -v --progress \
+    --transfers 4 --checkers 8 \
+    --drive-shared-with-me \
+    GoogleDrive:/${VERSION}/${ARCHIVE}/${REMOTE_DIR} \
+    "$OUTDIR"

--- a/catalogs/obs/catalog/MSWEP/scripts/download.sh
+++ b/catalogs/obs/catalog/MSWEP/scripts/download.sh
@@ -22,9 +22,9 @@
 set -e
 
 RESOLUTION="monthly"
-ARCHIVE="Past"
-VERSION="MSWEP_V316_test"
-OUTDIR="/scratch/project_465002727/mnurisso/MSWEP/v3.16"
+ARCHIVE="NRT"
+VERSION="MSWEP_V280"
+OUTDIR="/aqua/work/users/aqua-dvc/datasets/MSWEP/v2.8/netcdf/NRT"
 
 usage() {
     echo "Usage: $0 -o <outdir> [-r 3hourly|daily|monthly] [-a Past|NRT] [-v <gdrive-version-folder>]"

--- a/catalogs/obs/catalog/MSWEP/scripts/rechunk_nrt_monthly.sh
+++ b/catalogs/obs/catalog/MSWEP/scripts/rechunk_nrt_monthly.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#SBATCH --job-name=3hre
+#SBATCH --mail-type=ALL
+#SBATCH --time=770:00:00
+#SBATCH --output=/data/datasets/obs/MSWEP_V280/log/3hre_%j.log
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1 
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+
+cd /aqua/work/users/aqua-dvc/datasets/MSWEP/v2.8/netcdf
+
+# >>> mamba initialize >>>
+# !! Contents within this block are managed by 'mamba shell init' !!
+export MAMBA_EXE='/aqua/work/users/mnurisso/miniforge3/bin/mamba';
+export MAMBA_ROOT_PREFIX='/aqua/work/users/mnurisso/miniforge3';
+__mamba_setup="$("$MAMBA_EXE" shell hook --shell bash --root-prefix "$MAMBA_ROOT_PREFIX" 2> /dev/null)"
+if [ $? -eq 0 ]; then
+    eval "$__mamba_setup"
+else
+    alias mamba="$MAMBA_EXE"  # Fallback on help from mamba activate
+fi
+mamba activate aqua-dev
+
+INDIR=NRT
+OUTDIR=NRT_rechunked
+
+ulimit -n 4096
+
+mkdir -p $OUTDIR
+
+export CDO_NC_CHUNKSIZE=lat=1800,lon=3600,time=1
+
+y1=2021
+y2=2025
+
+for ((y=y1; y<=y2; y++)); do
+
+ echo $y
+ cdo -z zip_1 -k grid -f nc4 -cat -apply,-selname,precipitation [ $INDIR/${y}??.nc ] $OUTDIR/MSWEP_v280_monthly_$y.nc
+
+ cdo settime,0 $OUTDIR/MSWEP_v280_monthly_$y.nc $OUTDIR/MSWEP_v280_monthly_${y}_fixed.nc
+ mv $OUTDIR/MSWEP_v280_monthly_${y}_fixed.nc $OUTDIR/MSWEP_v280_monthly_$y.nc
+
+done    
+
+
+

--- a/catalogs/obs/catalog/MSWEP/v2.8.yaml
+++ b/catalogs/obs/catalog/MSWEP/v2.8.yaml
@@ -1,7 +1,3 @@
-plugins:
-  source:
-    - module: intake_xarray
-
 sources:
 
   monthly-zarr:


### PR DESCRIPTION
## PR description:

Script to download MSWEP v316_test from Google Drive

 - [ ] General README is updated if a new catalog is added.
 - [ ] Fixes are added to AQUA if new fixes are needed.
 - [ ] Grids are added to AQUA if new grids are needed.
 - [ ] Specific catalog README file is updated or added if needed (note of caution, errata, work to be done, etc.).
 - [ ] Tests are passing.
