### PR TITLE
IFS-NEMO-5km projections-ssp126 in climatedt-gen2 and other fixes

### DIFF
--- a/catalogs/climatedt-gen2/catalog.yaml
+++ b/catalogs/climatedt-gen2/catalog.yaml
@@ -15,6 +15,11 @@ sources:
     driver: yaml_file_cat
     args:
       path: '{{CATALOG_DIR}}/catalog/IFS-NEMO-5km/main.yaml'
+  IFS-NEMO-10km:
+    description: IFS-NEMO model at 10km resolution
+    driver: yaml_file_cat
+    args:
+      path: '{{CATALOG_DIR}}/catalog/IFS-NEMO-10km/main.yaml'
   IFS-FESOM-5km:
     description: IFS-FESOM coupled model at 5km resolution
     driver: yaml_file_cat

--- a/catalogs/climatedt-gen2/catalog/ICON-5km/projections-ssp370.yaml
+++ b/catalogs/climatedt-gen2/catalog/ICON-5km/projections-ssp370.yaml
@@ -19,7 +19,8 @@ sources:
         param: 78
         levtype: sfc
       data_start_date: 20150101T0000
-      data_end_date: 20370501T2300
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
       chunks: D
       savefreq: h
       timestep: h
@@ -55,7 +56,8 @@ sources:
         param: 78
         levtype: sfc
       data_start_date: 20150101T0000
-      data_end_date: 20370501T2300
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
       chunks: D
       savefreq: h
       timestep: h
@@ -91,8 +93,8 @@ sources:
         param: 235087
         levtype: sfc
       data_start_date: 20150101T0000
-      data_end_date: 20370501T2300
-      bridge_end_date: 20361231T2300
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
       chunks: MS
       savefreq: MS
       timestep: h
@@ -128,8 +130,8 @@ sources:
         param: 235087
         levtype: sfc
       data_start_date: 20150101T0000
-      data_end_date: 20370501T2300
-      bridge_end_date: 20361231T2300
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
       chunks: MS
       savefreq: MS
       timestep: h
@@ -165,7 +167,8 @@ sources:
         param: 172
         levtype: sfc
       data_start_date: 20150101T0000
-      data_end_date: 20370501T2300
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
       chunks: D
       savefreq: D
       timestep: h
@@ -198,7 +201,8 @@ sources:
         param: 172
         levtype: sfc
       data_start_date: 20150101T0000
-      data_end_date: 20370501T2300
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
       chunks: D
       savefreq: D
       timestep: h
@@ -233,7 +237,8 @@ sources:
         levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
             600, 700, 850, 925, 1000]
       data_start_date: 20150101T0000
-      data_end_date: 20370501T2300
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
       chunks: 6h
       savefreq: h
       timestep: h
@@ -270,7 +275,8 @@ sources:
         levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
             600, 700, 850, 925, 1000]
       data_start_date: 20150101T0000
-      data_end_date: 20370501T2300
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
       chunks: 6h
       savefreq: h
       timestep: h
@@ -307,8 +313,8 @@ sources:
         levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
             600, 700, 850, 925, 1000]
       data_start_date: 20150101T0000
-      data_end_date: 20370501T2300
-      bridge_end_date: 20361231T2300
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
       chunks: MS
       savefreq: MS
       timestep: h
@@ -344,7 +350,8 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20150101T0000
-      data_end_date: 20370501T2300
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
       chunks: D
       savefreq: D
       timestep: h
@@ -378,7 +385,8 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20150101T0000
-      data_end_date: 20370501T2300
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
       chunks: D
       savefreq: D
       timestep: h
@@ -412,8 +420,8 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20150101T0000
-      data_end_date: 20370501T2300
-      bridge_end_date: 20361231T2300
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
       chunks: MS
       savefreq: MS
       timestep: h
@@ -447,8 +455,8 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20150101T0000
-      data_end_date: 20370501T2300
-      bridge_end_date: 20361231T2300
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
       chunks: MS
       savefreq: MS
       timestep: h
@@ -486,7 +494,8 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72]
       data_start_date: 20150101T0000
-      data_end_date: 20370501T2300
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
       chunks: D
       savefreq: D
       timestep: h
@@ -532,7 +541,8 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72]
       data_start_date: 20150101T0000
-      data_end_date: 20370501T2300
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
       chunks: D
       savefreq: D
       timestep: h
@@ -578,8 +588,8 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72]
       data_start_date: 20150101T0000
-      data_end_date: 20370501T2300
-      bridge_end_date: 20361231T2300
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
       chunks: MS
       savefreq: MS
       timestep: h
@@ -625,8 +635,8 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72]
       data_start_date: 20150101T0000
-      data_end_date: 20370501T2300
-      bridge_end_date: 20361231T2300
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
       chunks: MS
       savefreq: MS
       timestep: h
@@ -669,7 +679,8 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20150101T0000
-      data_end_date: 20370501T2300
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
       chunks: D
       savefreq: h
       timestep: h
@@ -704,7 +715,8 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20150101T0000
-      data_end_date: 20370501T2300
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
       chunks: D
       savefreq: h
       timestep: h
@@ -739,8 +751,8 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20150101T0000
-      data_end_date: 20370501T2300
-      bridge_end_date: 20361231T2300
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
       chunks: MS
       savefreq: MS
       timestep: h
@@ -775,8 +787,8 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20150101T0000
-      data_end_date: 20370501T2300
-      bridge_end_date: 20361231T2300
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
       chunks: MS
       savefreq: MS
       timestep: h

--- a/catalogs/climatedt-gen2/catalog/IFS-FESOM-10km/story-nudging-Tplus2K.yaml
+++ b/catalogs/climatedt-gen2/catalog/IFS-FESOM-10km/story-nudging-Tplus2K.yaml
@@ -19,7 +19,7 @@ sources:
         param: 78
         levtype: sfc
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -61,7 +61,7 @@ sources:
         param: 78
         levtype: sfc
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -104,7 +104,7 @@ sources:
         param: 235087
         levtype: sfc
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -147,7 +147,7 @@ sources:
         param: 235087
         levtype: sfc
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -190,7 +190,7 @@ sources:
         param: 172
         levtype: sfc
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -230,7 +230,7 @@ sources:
         param: 172
         levtype: sfc
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -272,7 +272,7 @@ sources:
         levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
             600, 700, 850, 925, 1000]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: 6h
       savefreq: h
@@ -316,7 +316,7 @@ sources:
         levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
             600, 700, 850, 925, 1000]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: 6h
       savefreq: h
@@ -360,7 +360,7 @@ sources:
         levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
             600, 700, 850, 925, 1000]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -403,7 +403,7 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -444,7 +444,7 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -485,7 +485,7 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -526,7 +526,7 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -571,7 +571,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -621,7 +621,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -671,7 +671,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -721,7 +721,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -771,7 +771,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -823,7 +823,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -875,7 +875,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -924,7 +924,7 @@ sources:
         levtype: hl
         levelist: [100]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -966,7 +966,7 @@ sources:
         levtype: hl
         levelist: [100]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -1008,7 +1008,7 @@ sources:
         levtype: hl
         levelist: [100]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -1050,7 +1050,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -1092,7 +1092,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -1134,7 +1134,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -1176,7 +1176,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -1218,7 +1218,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -1260,7 +1260,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -1302,7 +1302,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -1344,7 +1344,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS

--- a/catalogs/climatedt-gen2/catalog/IFS-FESOM-10km/story-nudging-cont.yaml
+++ b/catalogs/climatedt-gen2/catalog/IFS-FESOM-10km/story-nudging-cont.yaml
@@ -19,7 +19,7 @@ sources:
         param: 78
         levtype: sfc
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -62,7 +62,7 @@ sources:
         param: 78
         levtype: sfc
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -105,7 +105,7 @@ sources:
         param: 235087
         levtype: sfc
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -148,7 +148,7 @@ sources:
         param: 235087
         levtype: sfc
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -191,7 +191,7 @@ sources:
         param: 172
         levtype: sfc
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -231,7 +231,7 @@ sources:
         param: 172
         levtype: sfc
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -273,7 +273,7 @@ sources:
         levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
             600, 700, 850, 925, 1000]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: 6h
       savefreq: h
@@ -317,7 +317,7 @@ sources:
         levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
             600, 700, 850, 925, 1000]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: 6h
       savefreq: h
@@ -361,7 +361,7 @@ sources:
         levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
             600, 700, 850, 925, 1000]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -404,7 +404,7 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -445,7 +445,7 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -486,7 +486,7 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -527,7 +527,7 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -572,7 +572,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -622,7 +622,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -672,7 +672,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -722,7 +722,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -772,7 +772,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -824,7 +824,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -876,7 +876,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -925,7 +925,7 @@ sources:
         levtype: hl
         levelist: [100]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -967,7 +967,7 @@ sources:
         levtype: hl
         levelist: [100]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -1009,7 +1009,7 @@ sources:
         levtype: hl
         levelist: [100]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -1051,7 +1051,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -1093,7 +1093,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -1135,7 +1135,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -1177,7 +1177,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -1219,7 +1219,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -1261,7 +1261,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -1303,7 +1303,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -1345,7 +1345,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS

--- a/catalogs/climatedt-gen2/catalog/IFS-FESOM-10km/story-nudging-hist.yaml
+++ b/catalogs/climatedt-gen2/catalog/IFS-FESOM-10km/story-nudging-hist.yaml
@@ -19,7 +19,7 @@ sources:
         param: 78
         levtype: sfc
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -62,7 +62,7 @@ sources:
         param: 78
         levtype: sfc
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -105,7 +105,7 @@ sources:
         param: 235087
         levtype: sfc
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -148,7 +148,7 @@ sources:
         param: 235087
         levtype: sfc
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -191,7 +191,7 @@ sources:
         param: 172
         levtype: sfc
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -231,7 +231,7 @@ sources:
         param: 172
         levtype: sfc
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -273,7 +273,7 @@ sources:
         levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
             600, 700, 850, 925, 1000]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: 6h
       savefreq: h
@@ -317,7 +317,7 @@ sources:
         levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
             600, 700, 850, 925, 1000]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: 6h
       savefreq: h
@@ -361,7 +361,7 @@ sources:
         levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
             600, 700, 850, 925, 1000]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -404,7 +404,7 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -445,7 +445,7 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -486,7 +486,7 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -527,7 +527,7 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -572,7 +572,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -622,7 +622,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -672,7 +672,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -722,7 +722,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -772,7 +772,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -824,7 +824,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -876,7 +876,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -925,7 +925,7 @@ sources:
         levtype: hl
         levelist: [100]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -967,7 +967,7 @@ sources:
         levtype: hl
         levelist: [100]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -1009,7 +1009,7 @@ sources:
         levtype: hl
         levelist: [100]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -1051,7 +1051,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -1093,7 +1093,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -1135,7 +1135,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -1177,7 +1177,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -1219,7 +1219,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -1261,7 +1261,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -1303,7 +1303,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -1345,7 +1345,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4]
       data_start_date: 20170101T0000
-      data_end_date: 20241231T2300
+      data_end_date: 20260731T2300
       data_bridge_start_date: complete
       chunks: MS
       savefreq: MS

--- a/catalogs/climatedt-gen2/catalog/IFS-FESOM-5km/projections-ssp370.yaml
+++ b/catalogs/climatedt-gen2/catalog/IFS-FESOM-5km/projections-ssp370.yaml
@@ -18,7 +18,7 @@ sources:
         param: 78
         levtype: sfc
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -55,7 +55,7 @@ sources:
         param: 78
         levtype: sfc
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -92,7 +92,7 @@ sources:
         param: 235087
         levtype: sfc
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -129,7 +129,7 @@ sources:
         param: 235087
         levtype: sfc
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -166,7 +166,7 @@ sources:
         param: 172
         levtype: sfc
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -200,7 +200,7 @@ sources:
         param: 172
         levtype: sfc
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -236,7 +236,7 @@ sources:
         levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
             600, 700, 850, 925, 1000]
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: 6h
       savefreq: h
@@ -274,7 +274,7 @@ sources:
         levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
             600, 700, 850, 925, 1000]
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: 6h
       savefreq: h
@@ -312,7 +312,7 @@ sources:
         levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
             600, 700, 850, 925, 1000]
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -349,7 +349,7 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -384,7 +384,7 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -419,7 +419,7 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -454,7 +454,7 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -493,7 +493,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69]
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -537,7 +537,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69]
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -581,7 +581,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69]
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -625,7 +625,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69]
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -669,7 +669,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70]
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -715,7 +715,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70]
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -761,7 +761,7 @@ sources:
           37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70]
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -804,7 +804,7 @@ sources:
         levtype: hl
         levelist: [100]
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -840,7 +840,7 @@ sources:
         levtype: hl
         levelist: [100]
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -876,7 +876,7 @@ sources:
         levtype: hl
         levelist: [100]
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -912,7 +912,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -948,7 +948,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -984,7 +984,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -1020,7 +1020,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -1056,7 +1056,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4]
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -1092,7 +1092,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4]
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -1128,7 +1128,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4]
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -1164,7 +1164,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4]
       data_start_date: 20150101T0000
-      data_end_date: 20500101T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: MS
       savefreq: MS

--- a/catalogs/climatedt-gen2/catalog/IFS-NEMO-5km/main.yaml
+++ b/catalogs/climatedt-gen2/catalog/IFS-NEMO-5km/main.yaml
@@ -50,6 +50,24 @@ sources:
     driver: yaml_file_cat
     args:
       path: '{{CATALOG_DIR}}/baseline-hist.yaml'
+  projections-ssp126:
+    description: '"IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12"'
+    metadata:
+      author: bsc655096
+      maintainer: not specified
+      machine: mn5
+      expid: o031
+      resolution_atm: tco2559
+      resolution_oce: eORCA12
+      forcing: projections-ssp1-2-6
+      start: '2015'
+      dashboard:
+        menu: projections-ssp126
+        resolution_id: HR
+        note: null
+    driver: yaml_file_cat
+    args:
+      path: '{{CATALOG_DIR}}/projections-ssp126.yaml'
   projections-ssp370:
     description: '"IFS-NEMO ssp370 2015, grids: tco2559 eORCA12"'
     metadata:

--- a/catalogs/climatedt-gen2/catalog/IFS-NEMO-5km/projections-ssp126.yaml
+++ b/catalogs/climatedt-gen2/catalog/IFS-NEMO-5km/projections-ssp126.yaml
@@ -1,0 +1,1152 @@
+sources:
+  hourly-hpz10-sfc:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: high
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clte
+        date: 20150101
+        time: 0000
+        param: 78
+        levtype: sfc
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: D
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [78, 79, 134, 136, 137, 151, 165, 166, 167, 168, 207, 235, 
+          228141, 228164, 235020, 235021, 235031, 235033, 235034, 235035, 235036,
+        235037, 235038, 235039, 235040, 235041, 235042, 235043, 235049, 235050, 
+          235051, 235052, 235053, 235055]
+      source_grid_name: hpz10-nested
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  hourly-hpz7-sfc:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clte
+        date: 20150101
+        time: 0000
+        param: 78
+        levtype: sfc
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: D
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [78, 79, 134, 136, 137, 151, 165, 166, 167, 168, 207, 235, 
+          228141, 228164, 235020, 235021, 235031, 235033, 235034, 235035, 235036,
+        235037, 235038, 235039, 235040, 235041, 235042, 235043, 235049, 235050, 
+          235051, 235052, 235053, 235055]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  monthly-hpz10-sfc:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: high
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clmn
+        year: 2015
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 235087
+        levtype: sfc
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [235087, 235088, 235134, 235136, 235137, 235151, 235165, 235166,
+        228004, 235168, 228005, 235079, 235078, 235288, 235020, 235021, 235031, 
+          235033, 235034, 235035, 235036, 235037, 235038, 235039, 235040, 235041,
+        235042, 235043, 235049, 235050, 235051, 235052, 235053, 235055]
+      source_grid_name: hpz10-nested
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  monthly-hpz7-sfc:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clmn
+        year: 2015
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 235087
+        levtype: sfc
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [235087, 235088, 235134, 235136, 235137, 235151, 235165, 235166,
+        228004, 235168, 228005, 235079, 235078, 235288, 235020, 235021, 235031, 
+          235033, 235034, 235035, 235036, 235037, 235038, 235039, 235040, 235041,
+        235042, 235043, 235049, 235050, 235051, 235052, 235053, 235055]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  daily-hpz10-sfc:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: high
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clte
+        date: 20150101
+        time: 0000
+        param: 172
+        levtype: sfc
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: D
+      savefreq: D
+      timestep: h
+      timestyle: date
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [172, 228002]
+      source_grid_name: hpz10-nested
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  daily-hpz7-sfc:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clte
+        date: 20150101
+        time: 0000
+        param: 172
+        levtype: sfc
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: D
+      savefreq: D
+      timestep: h
+      timestyle: date
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [172, 228002]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  hourly-hpz10-pl:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: high
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clte
+        date: 20150101
+        time: 0000
+        param: 60
+        levtype: pl
+        levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
+            600, 700, 850, 925, 1000]
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: 6h
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 
+          700, 850, 925, 1000]
+      variables: [60, 129, 130, 131, 132, 133, 135, 157, 246]
+      source_grid_name: hpz10-nested
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  hourly-hpz7-pl:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clte
+        date: 20150101
+        time: 0000
+        param: 60
+        levtype: pl
+        levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
+            600, 700, 850, 925, 1000]
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: 6h
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 
+          700, 850, 925, 1000]
+      variables: [60, 129, 130, 131, 132, 133, 135, 157, 246]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  monthly-hpz7-pl:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clmn
+        year: 2015
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 235100
+        levtype: pl
+        levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
+            600, 700, 850, 925, 1000]
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 600, 
+          700, 850, 925, 1000]
+      variables: [235100, 235129, 235130, 235131, 235132, 235133, 235135, 235157,
+        235246]
+      source_grid_name: hpz7-nested
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  daily-hpz10-o2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: high
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clte
+        date: 20150101
+        time: 0000
+        param: 263000
+        levtype: o2d
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: D
+      savefreq: D
+      timestep: h
+      timestyle: date
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [263000, 263001, 263003, 263004, 263008, 263009, 263100, 263101,
+        263121, 263122, 263123, 263124]
+      source_grid_name: nemo-eORCA12-hpz10-nested-v3
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  daily-hpz7-o2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clte
+        date: 20150101
+        time: 0000
+        param: 263000
+        levtype: o2d
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: D
+      savefreq: D
+      timestep: h
+      timestyle: date
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [263000, 263001, 263003, 263004, 263008, 263009, 263100, 263101,
+        263121, 263122, 263123, 263124]
+      source_grid_name: nemo-eORCA12-hpz7-nested-v3
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  monthly-hpz10-o2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: high
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clmn
+        year: 2015
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 263000
+        levtype: o2d
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [263000, 263001, 263003, 263004, 263008, 263009, 263100, 263101,
+        263121, 263122, 263123, 263124]
+      source_grid_name: nemo-eORCA12-hpz10-nested-v3
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  monthly-hpz7-o2d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clmn
+        year: 2015
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 263000
+        levtype: o2d
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      variables: [263000, 263001, 263003, 263004, 263008, 263009, 263100, 263101,
+        263121, 263122, 263123, 263124]
+      source_grid_name: nemo-eORCA12-hpz7-nested-v3
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  daily-hpz10-o3d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: high
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clte
+        date: 20150101
+        time: 0000
+        param: 263500
+        levtype: o3d
+        levelist: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+          19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
+          37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
+          55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72,
+          73, 74, 75]
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: D
+      savefreq: D
+      timestep: h
+      timestyle: date
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [0.5057600140571594, 1.5558552742004395, 2.6676816940307617, 
+          3.8562798500061035, 5.140361309051514, 6.543033599853516, 
+          8.09251880645752, 9.822750091552734, 11.773679733276367, 
+          13.99103832244873, 16.52532196044922, 19.42980194091797, 
+          22.75761604309082, 26.558300018310547, 30.874561309814453, 
+          35.740203857421875, 41.180023193359375, 47.21189498901367, 
+          53.85063552856445, 61.11283874511719, 69.02168273925781, 
+          77.61116027832031, 86.92942810058594, 97.04131317138672, 
+          108.03028106689453, 120.0, 133.07582092285156, 147.40625, 
+          163.16445922851562, 180.5499267578125, 199.7899627685547, 
+          221.14117431640625, 244.890625, 271.35638427734375, 300.88751220703125,
+        333.8628234863281, 370.6884765625, 411.7938537597656, 457.6256103515625, 
+          508.639892578125, 565.2922973632812, 628.0260009765625, 
+          697.2586669921875, 773.3682861328125, 856.678955078125, 
+          947.4478759765625, 1045.854248046875, 1151.9912109375, 
+          1265.8614501953125, 1387.376953125, 1516.3636474609375, 
+          1652.5684814453125, 1795.6707763671875, 1945.2955322265625, 
+          2101.026611328125, 2262.421630859375, 2429.025146484375, 
+          2600.38037109375, 2776.039306640625, 2955.5703125, 3138.56494140625, 
+          3324.640869140625, 3513.445556640625, 3704.65673828125, 
+          3897.98193359375, 4093.15869140625, 4289.95263671875, 4488.15478515625,
+        4687.5810546875, 4888.06982421875, 5089.478515625, 5291.68310546875, 
+          5494.5751953125, 5698.060546875, 5902.0576171875]
+      variables: [263500, 263501, 263505, 263506, 263507]
+      source_grid_name: nemo-eORCA12-hpz10-nested-3d-v3
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  daily-hpz7-o3d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clte
+        date: 20150101
+        time: 0000
+        param: 263500
+        levtype: o3d
+        levelist: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+          19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
+          37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
+          55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72,
+          73, 74, 75]
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: D
+      savefreq: D
+      timestep: h
+      timestyle: date
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [0.5057600140571594, 1.5558552742004395, 2.6676816940307617, 
+          3.8562798500061035, 5.140361309051514, 6.543033599853516, 
+          8.09251880645752, 9.822750091552734, 11.773679733276367, 
+          13.99103832244873, 16.52532196044922, 19.42980194091797, 
+          22.75761604309082, 26.558300018310547, 30.874561309814453, 
+          35.740203857421875, 41.180023193359375, 47.21189498901367, 
+          53.85063552856445, 61.11283874511719, 69.02168273925781, 
+          77.61116027832031, 86.92942810058594, 97.04131317138672, 
+          108.03028106689453, 120.0, 133.07582092285156, 147.40625, 
+          163.16445922851562, 180.5499267578125, 199.7899627685547, 
+          221.14117431640625, 244.890625, 271.35638427734375, 300.88751220703125,
+        333.8628234863281, 370.6884765625, 411.7938537597656, 457.6256103515625, 
+          508.639892578125, 565.2922973632812, 628.0260009765625, 
+          697.2586669921875, 773.3682861328125, 856.678955078125, 
+          947.4478759765625, 1045.854248046875, 1151.9912109375, 
+          1265.8614501953125, 1387.376953125, 1516.3636474609375, 
+          1652.5684814453125, 1795.6707763671875, 1945.2955322265625, 
+          2101.026611328125, 2262.421630859375, 2429.025146484375, 
+          2600.38037109375, 2776.039306640625, 2955.5703125, 3138.56494140625, 
+          3324.640869140625, 3513.445556640625, 3704.65673828125, 
+          3897.98193359375, 4093.15869140625, 4289.95263671875, 4488.15478515625,
+        4687.5810546875, 4888.06982421875, 5089.478515625, 5291.68310546875, 
+          5494.5751953125, 5698.060546875, 5902.0576171875]
+      variables: [263500, 263501, 263505, 263506, 263507]
+      source_grid_name: nemo-eORCA12-hpz7-nested-3d-v3
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  monthly-hpz10-o3d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: high
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clmn
+        year: 2015
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 263505
+        levtype: o3d
+        levelist: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+          19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
+          37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
+          55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72,
+          73, 74, 75]
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [0.5057600140571594, 1.5558552742004395, 2.6676816940307617, 
+          3.8562798500061035, 5.140361309051514, 6.543033599853516, 
+          8.09251880645752, 9.822750091552734, 11.773679733276367, 
+          13.99103832244873, 16.52532196044922, 19.42980194091797, 
+          22.75761604309082, 26.558300018310547, 30.874561309814453, 
+          35.740203857421875, 41.180023193359375, 47.21189498901367, 
+          53.85063552856445, 61.11283874511719, 69.02168273925781, 
+          77.61116027832031, 86.92942810058594, 97.04131317138672, 
+          108.03028106689453, 120.0, 133.07582092285156, 147.40625, 
+          163.16445922851562, 180.5499267578125, 199.7899627685547, 
+          221.14117431640625, 244.890625, 271.35638427734375, 300.88751220703125,
+        333.8628234863281, 370.6884765625, 411.7938537597656, 457.6256103515625, 
+          508.639892578125, 565.2922973632812, 628.0260009765625, 
+          697.2586669921875, 773.3682861328125, 856.678955078125, 
+          947.4478759765625, 1045.854248046875, 1151.9912109375, 
+          1265.8614501953125, 1387.376953125, 1516.3636474609375, 
+          1652.5684814453125, 1795.6707763671875, 1945.2955322265625, 
+          2101.026611328125, 2262.421630859375, 2429.025146484375, 
+          2600.38037109375, 2776.039306640625, 2955.5703125, 3138.56494140625, 
+          3324.640869140625, 3513.445556640625, 3704.65673828125, 
+          3897.98193359375, 4093.15869140625, 4289.95263671875, 4488.15478515625,
+        4687.5810546875, 4888.06982421875, 5089.478515625, 5291.68310546875, 
+          5494.5751953125, 5698.060546875, 5902.0576171875]
+      variables: [263505]
+      source_grid_name: nemo-eORCA12-hpz10-nested-3d-v3
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  monthly-hpz7-o3d:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clmn
+        year: 2015
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 263505
+        levtype: o3d
+        levelist: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+          19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
+          37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
+          55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72,
+          73, 74, 75]
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [0.5057600140571594, 1.5558552742004395, 2.6676816940307617, 
+          3.8562798500061035, 5.140361309051514, 6.543033599853516, 
+          8.09251880645752, 9.822750091552734, 11.773679733276367, 
+          13.99103832244873, 16.52532196044922, 19.42980194091797, 
+          22.75761604309082, 26.558300018310547, 30.874561309814453, 
+          35.740203857421875, 41.180023193359375, 47.21189498901367, 
+          53.85063552856445, 61.11283874511719, 69.02168273925781, 
+          77.61116027832031, 86.92942810058594, 97.04131317138672, 
+          108.03028106689453, 120.0, 133.07582092285156, 147.40625, 
+          163.16445922851562, 180.5499267578125, 199.7899627685547, 
+          221.14117431640625, 244.890625, 271.35638427734375, 300.88751220703125,
+        333.8628234863281, 370.6884765625, 411.7938537597656, 457.6256103515625, 
+          508.639892578125, 565.2922973632812, 628.0260009765625, 
+          697.2586669921875, 773.3682861328125, 856.678955078125, 
+          947.4478759765625, 1045.854248046875, 1151.9912109375, 
+          1265.8614501953125, 1387.376953125, 1516.3636474609375, 
+          1652.5684814453125, 1795.6707763671875, 1945.2955322265625, 
+          2101.026611328125, 2262.421630859375, 2429.025146484375, 
+          2600.38037109375, 2776.039306640625, 2955.5703125, 3138.56494140625, 
+          3324.640869140625, 3513.445556640625, 3704.65673828125, 
+          3897.98193359375, 4093.15869140625, 4289.95263671875, 4488.15478515625,
+        4687.5810546875, 4888.06982421875, 5089.478515625, 5291.68310546875, 
+          5494.5751953125, 5698.060546875, 5902.0576171875]
+      variables: [263505, 263500, 263501, 263506, 263507]
+      source_grid_name: nemo-eORCA12-hpz7-nested-3d-v3
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  hourly-hpz10-hl:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: high
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clte
+        date: 20150101
+        time: 0000
+        param: 131
+        levtype: hl
+        levelist: [100]
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: D
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [100]
+      variables: [131, 132]
+      source_grid_name: hpz10
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  hourly-hpz7-hl:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clte
+        date: 20150101
+        time: 0000
+        param: 131
+        levtype: hl
+        levelist: [100]
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: D
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [100]
+      variables: [131, 132]
+      source_grid_name: hpz7
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  monthly-hpz7-hl:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clmn
+        year: 2015
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 235131
+        levtype: hl
+        levelist: [100]
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [100]
+      variables: [235131, 235132]
+      source_grid_name: hpz7
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  hourly-hpz10-sol5:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: high
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clte
+        date: 20150101
+        time: 0000
+        param: 228141
+        levtype: sol
+        levelist: [1, 2, 3, 4, 5]
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: D
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [1, 2, 3, 4, 5]
+      variables: [228141]
+      source_grid_name: hpz10
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  hourly-hpz7-sol5:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clte
+        date: 20150101
+        time: 0000
+        param: 228141
+        levtype: sol
+        levelist: [1, 2, 3, 4, 5]
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: D
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [1, 2, 3, 4, 5]
+      variables: [228141]
+      source_grid_name: hpz7
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  monthly-hpz10-sol5:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: high
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clmn
+        year: 2015
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 235078
+        levtype: sol
+        levelist: [1, 2, 3, 4, 5]
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [1, 2, 3, 4, 5]
+      variables: [235078]
+      source_grid_name: hpz10
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  monthly-hpz7-sol5:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clmn
+        year: 2015
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 235078
+        levtype: sol
+        levelist: [1, 2, 3, 4, 5]
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [1, 2, 3, 4, 5]
+      variables: [235078]
+      source_grid_name: hpz7
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  hourly-hpz10-sol4:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: high
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clte
+        date: 20150101
+        time: 0000
+        param: 260199
+        levtype: sol
+        levelist: [1, 2, 3, 4]
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: D
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [1, 2, 3, 4]
+      variables: [260199, 260360]
+      source_grid_name: hpz10
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  hourly-hpz7-sol4:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clte
+        date: 20150101
+        time: 0000
+        param: 260199
+        levtype: sol
+        levelist: [1, 2, 3, 4]
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: D
+      savefreq: h
+      timestep: h
+      timestyle: date
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [1, 2, 3, 4]
+      variables: [260199, 260360]
+      source_grid_name: hpz7
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  monthly-hpz10-sol4:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: high
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clmn
+        year: 2015
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 235077
+        levtype: sol
+        levelist: [1, 2, 3, 4]
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [1, 2, 3, 4]
+      variables: [235077, 235094]
+      source_grid_name: hpz10
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  monthly-hpz7-sol4:
+    args:
+      request:
+        class: d1
+        dataset: climate-dt
+        activity: projections  # To be overwritten by workflow/config file
+        experiment: SSP1-2.6  # To be overwritten by workflow/config file
+        generation: 2  # To be overwritten by workflow/config file
+        model: IFS-NEMO
+        realization: 1
+        resolution: standard
+        expver: 0001  # To be overwritten by workflow/config file
+        expid: o031
+        type: fc
+        stream: clmn
+        year: 2015
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        param: 235077
+        levtype: sol
+        levelist: [1, 2, 3, 4]
+      data_start_date: 20150101T0000
+      data_end_date: 20491231T2300
+      bridge_start_date: complete
+      chunks: MS
+      savefreq: MS
+      timestep: h
+      timestyle: yearmonth
+    description: 'IFS-NEMO-5km projections-ssp126 2015, grids: tco2559 eORCA12'
+    driver: gsv
+    metadata:
+      fdb_home: /gpfs/projects/ehpc01/dte/fdb
+      levels: [1, 2, 3, 4]
+      variables: [235077, 235094]
+      source_grid_name: hpz7
+      fixer_name: climatedt-phase2-production
+      fdb_info_file: /gpfs/scratch/ehpc123/bsc655096/o031/o031.yaml
+  lra-r100-monthly:
+    driver: netcdf
+    description: AQUA netcdf DROP-generated data monthly at r100
+    args:
+      urlpath: 
+        - '{{ LRA_PATH }}/IFS-NEMO-5km/projections-ssp126/global/*o00q_r100_monthly_*.nc'
+        # Legacy path in the MN5 operational project
+        # /gpfs/scratch/ehpc123/bsc655096/o031/output/LRA/climatedt-gen2/IFS-NEMO-5km/projections-ssp126/{{realization}}/r100/monthly/{{stat}}/{{region}}/*_climatedt-gen2_IFS-NEMO-5km_projections-ssp126_{{realization}}_r100_monthly_{{stat}}_{{region}}_*.nc
+      chunks:
+        lat: 180
+        lon: 360
+        time: 12
+      xarray_kwargs:
+        decode_times: true
+        combine: by_coords
+    metadata:
+      source_grid_name: r100
+    parameters:
+      realization:
+        description: Parameter realization
+        default: r1
+        type: str
+        allowed:
+        - r1
+      region:
+        description: Parameter region
+        default: global
+        type: str
+        allowed:
+        - global
+      stat:
+        description: Parameter stat
+        default: mean
+        type: str
+        allowed:
+        - mean

--- a/catalogs/climatedt-gen2/catalog/IFS-NEMO-5km/projections-ssp370.yaml
+++ b/catalogs/climatedt-gen2/catalog/IFS-NEMO-5km/projections-ssp370.yaml
@@ -18,7 +18,7 @@ sources:
         param: 78
         levtype: sfc
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -54,7 +54,7 @@ sources:
         param: 78
         levtype: sfc
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -90,7 +90,7 @@ sources:
         param: 235087
         levtype: sfc
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -126,7 +126,7 @@ sources:
         param: 235087
         levtype: sfc
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -162,7 +162,7 @@ sources:
         param: 172
         levtype: sfc
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -195,7 +195,7 @@ sources:
         param: 172
         levtype: sfc
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -230,7 +230,7 @@ sources:
         levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
             600, 700, 850, 925, 1000]
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: 6h
       savefreq: h
@@ -267,7 +267,7 @@ sources:
         levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
             600, 700, 850, 925, 1000]
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: 6h
       savefreq: h
@@ -304,7 +304,7 @@ sources:
         levelist: [1, 5, 10, 20, 30, 50, 70, 100, 150, 200, 250, 300, 400, 500, 
             600, 700, 850, 925, 1000]
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -340,7 +340,7 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -374,7 +374,7 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -408,7 +408,7 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -442,7 +442,7 @@ sources:
         param: 263000
         levtype: o2d
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -481,7 +481,7 @@ sources:
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72,
           73, 74, 75]
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -542,7 +542,7 @@ sources:
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72,
           73, 74, 75]
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: D
@@ -603,7 +603,7 @@ sources:
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72,
           73, 74, 75]
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -664,7 +664,7 @@ sources:
           55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72,
           73, 74, 75]
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -721,7 +721,7 @@ sources:
         levtype: hl
         levelist: [100]
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -756,7 +756,7 @@ sources:
         levtype: hl
         levelist: [100]
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -791,7 +791,7 @@ sources:
         levtype: hl
         levelist: [100]
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -826,7 +826,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -861,7 +861,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: D
       savefreq: h
@@ -896,7 +896,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: MS
       savefreq: MS
@@ -931,7 +931,7 @@ sources:
         levtype: sol
         levelist: [1, 2, 3, 4, 5]
       data_start_date: 20150101T0000
-      data_end_date: 20361231T2300
+      data_end_date: 20491231T2300
       bridge_start_date: complete
       chunks: MS
       savefreq: MS


### PR DESCRIPTION
## PR description:

IFS-NEMO-5km projections-ssp126 is added, completely on Bridge.
Other dates are fixed.
Storylines are extended up to 07/2026

## Issues closed by this pull request:

 - [x] Tests are passing.
